### PR TITLE
feat: RomM save sync, resume-from-state, and broker stability hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 **/*.pyo
 pine_diag.py
 README.md
+tests/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+pine_diag.py
+README.md

--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ docker compose up -d --force-recreate pcsx2
 
 ---
 
+## Memory Card Setup (required for save sync)
+
+**The PCSX2 memory card must be set to `Folder` type, not `File`.** This is the
+standard for this mod, and in-game save sync depends on it.
+
+A `File` card is a single monolithic 8 MB image holding every game's saves at
+once, so it cannot be synced per game or isolated per user. A `Folder` card
+stores each game in its own directory keyed by the game's serial ID (for
+example `BASLUS-20267DOTHACK/`), which is what lets the broker sync and hydrate
+one game's save without touching any other.
+
+Set it in PCSX2 under **Settings -> Memory Cards**: create a new card of type
+`Folder` and assign it to **Slot 1** (Slot 1 is the only slot synced). Confirm
+`inis/PCSX2.ini` shows the folder card on `Slot1_Filename`:
+
+```ini
+[MemoryCards]
+Slot1_Enable = true
+Slot1_Filename = my-folder-card.ps2   # this is a directory on disk, not a file
+```
+
+> Save **states** (`.p2s` snapshots, synced via `/state-file`) do not depend on
+> the memory card type. This requirement is only for in-game memory-card saves.
+
+---
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Slot1_Filename = my-folder-card.ps2   # this is a directory on disk, not a file
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish before serving the slot file. |
 | `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game VM to reach running state before giving up on the deferred state load. |
 | `RESUME_LOAD_SETTLE` | `3.0` | Seconds to let the game settle after the VM reports running, before the deferred `load_slot` state load fires. |
+| `SAVE_DATA_ROOT` | `/config/.config/PCSX2` | Override for the PCSX2 data dir the `/save-file` and `/memory-card` endpoints operate on. Only the `memcards/` subtree under it is synced. |
+| `BROKER_INITIAL_SLOT` | `1` | Fallback save state slot the broker assumes PCSX2 starts on when `SaveStateSlot` can't be read from `PCSX2.ini`. Only affects xdotool slot cycling. |
+| `PCSX2_LOG_PATH` | `/config/pcsx2-qt.log` | File that captures pcsx2-qt's stdout/stderr (renderer, Vulkan, Qt errors). Appended across launches. |
+| `BROKER_LOG_LEVEL` | `INFO` | Broker log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
 
 ---
 
@@ -141,11 +145,14 @@ Returns the current session.
   "active": true,
   "rom_path": "/romm/library/ps2/game.chd",
   "rom_name": "game",
-  "started_at": "2026-01-01T00:00:00Z"
+  "started_at": "2026-01-01T00:00:00Z",
+  "relaunch_abandoned": false
 }
 ```
 
 Returns `{"active": false, ...}` when no game is running.
+
+`relaunch_abandoned` is `true` once PCSX2 has exited within 5 s three times in a row and the broker has stopped restarting it — nothing is running and nothing will recover it without an explicit `POST /launch`. Monitor this to tell a container that is idle at the dashboard (`active: false`, `relaunch_abandoned: false`) from one that has given up (`active: false`, `relaunch_abandoned: true`); the latter needs intervention, usually a GPU/renderer failure visible in `PCSX2_LOG_PATH`.
 
 ---
 
@@ -159,7 +166,7 @@ Kills any running game and launches a new ROM. Returns immediately; launch runs 
 
 - `rom_path` must exist and be under `ROM_ROOT`
 - `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
-- Returns `409` if a save is in progress
+- Returns `409` if a save is in progress, a launch is already in progress, or a `/memory-card` replace is in flight
 - Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10
 - Returns `422` if `rom_path` does not exist
 
@@ -172,6 +179,8 @@ Kills any running game and launches a new ROM. Returns immediately; launch runs 
 ### `DELETE /launch`
 
 Stops the current game and returns PCSX2 to dashboard mode. Runs in background.
+
+- Returns `409` if a launch is already in progress
 
 ```json
 { "status": "resetting" }
@@ -264,6 +273,8 @@ Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centra
 - Response body is `application/octet-stream`; the emulator's own filename is echoed in the `X-State-Filename` header
 - Returns `404` if no state file exists for the slot
 - Returns `400` if `slot` is not an integer 0–10
+- Returns `503` if a save is still in flight after `STATE_GET_WAIT` — retry rather than accept a half-written file
+- Returns `413` if the state file exceeds 256 MB
 
 ---
 
@@ -277,6 +288,59 @@ Writes a state file into the sstates directory, used by RomM to hydrate a freshl
 
 ```json
 { "status": "ok", "filename": "SLUS-12345 (ABCD1234).03.p2s" }
+```
+
+---
+
+### `GET /save-file`
+
+Zips every in-game save (memory-card file under `memcards/`) modified since the last game launch, for RomM's end-of-session save pull. The baseline survives game exit, so the pull can happen after `/save-and-exit`.
+
+- Response body is `application/zip`; a suggested name is echoed in `X-Save-Filename`
+- Files still being written are skipped; their count is reported in `X-Save-Skipped-Unstable`
+- Returns `404` if no game has been launched, or nothing changed since the last launch
+- Returns `413` if the changed set exceeds 256 MB
+- Returns `503` if every changed file was mid-write — retry shortly
+
+---
+
+### `PUT /save-file`
+
+Restores a previously pulled save archive into the data dir, used to hydrate a container before launch. Files on disk newer than their archive member are skipped (last-write-wins), so a restore can never roll back saves made since the archive was taken.
+
+- Body is the raw zip (`Content-Length` required, max 256 MB)
+- Archive members must live under `memcards/`; anything else is rejected
+- Returns `400` for a bad/truncated archive or a member outside the allowed subtree
+- Returns `500` if some members could not be written — the response carries `written`/`skipped`/`failed` counts, and retrying the same archive is safe (idempotent)
+
+```json
+{ "status": "ok", "written": 3, "skipped": 1 }
+```
+
+---
+
+### `GET /memory-card`
+
+Serves the **entire** Slot-1 folder memory card (superblock plus every game folder) as one zip, member paths relative to the card root so the image is host- and card-name-independent. This is the per-user card evacuation for pooled containers; Slot 2 is never touched.
+
+- Response is `application/zip` with `X-Memory-Card-Slot: 1`
+- Returns `404` with header `X-Memory-Card: absent` if no folder card exists in slot 1 — the header distinguishes "genuinely empty" from a missing endpoint, which must not be treated as safe-to-wipe
+- Returns `409` if slot 1 is a File (`.ps2`) card — the whole-card sync requires a Folder card — or if another card operation is in progress
+
+---
+
+### `PUT /memory-card`
+
+Wipes the Slot-1 folder card and lays down the pulled card image (no per-file merge — full replace is the isolation guarantee for pooled containers). Extraction goes to a staging dir swapped atomically over the live card, so a mid-way failure never leaves a half-wiped card.
+
+- Body is the raw zip (`Content-Length` required, max 256 MB)
+- Refused while a game is running or a launch is in flight — PCSX2 holds the card open and replacing it mid-game corrupts it. Hydrate before launch or after exit. `POST /launch` is refused for the duration, so a launch cannot slip in mid-replace.
+- Dashboard crash recovery is *not* blocked during a replace: the gameless dashboard never opens a memory card, and the swap is atomic, so a relaunch mid-hydrate sees either the old card or the new one
+- Returns `409` if a game is running, a launch is in progress, or another card operation is in progress
+- Returns `400` for a bad/truncated archive, a member escaping the card dir, or when no Slot-1 card is configured
+
+```json
+{ "status": "ok", "written": 42 }
 ```
 
 ---
@@ -358,6 +422,22 @@ Expected on save-and-exit:
 14:25:49 [broker] INFO Launching PCSX2 (rom=dashboard)
 14:25:49 [broker] INFO PCSX2 launched (PID 456)
 ```
+
+---
+
+## Development
+
+The broker's logic is covered by a stdlib `unittest` suite — no pytest, no dependencies, nothing to install. Run it from the repo root:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+`tests/` is excluded from the image via `.dockerignore`, so it never ships in a build.
+
+The suite covers the save-file and memory-card archive handling (round trips, the last-write-wins mtime guard, path-traversal and subtree rejection, File-card refusal), `PCSX2.ini` patching and parsing, ROM path validation, and the session lifecycle state machine (crash-loop limiter, launch/card-op claims, deferred `load_slot` generation checks).
+
+Anything needing a real X display, PINE socket, or `pcsx2-qt` process is deliberately out of scope — those paths are only provable on a running container.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pcsx2-romm-integration
 
-A [LinuxServer Docker Mod](https://docs.linuxserver.io/general/container-customization) that integrates [PCSX2](https://pcsx2.net/) with [RomM](https://github.com/rommapp/romm) — launching PS2 games on demand from RomM's web UI and streaming the output back via Selkies.
+A [LinuxServer Docker Mod](https://docs.linuxserver.io/general/container-customization) for [PCSX2](https://pcsx2.net/) that connects to [RomM](https://github.com/rommapp/romm). Pick a game from the RomM web UI and the mod launches it in PCSX2, streaming the session back via Selkies.
 
 ---
 
@@ -10,7 +10,7 @@ This mod installs a small HTTP broker inside the [linuxserver/pcsx2](https://doc
 
 1. Exposes an API on port 8000 so RomM can request game launches
 2. Manages the PCSX2 process lifecycle (start, stop, game switching, dashboard mode)
-3. Saves game state via PCSX2's PINE IPC before exit
+3. Saves game state by sending an F-key to the PCSX2 window (via xdotool) before exit
 4. Patches Selkies and PCSX2 at init time for reliable controller and socket handling
 5. Supervises itself via s6-overlay (auto-restarts on crash)
 
@@ -63,9 +63,7 @@ docker compose up -d --force-recreate pcsx2
 | `BROKER_SECRET` | *(none)* | Shared secret for authentication. Sent as the `X-Broker-Secret` header. If unset, all requests are accepted — not recommended on a shared network. |
 | `BROKER_PORT` | `8000` | Port the broker HTTP server listens on. |
 | `ROM_ROOT` | `/romm/library` | Root path inside the container where ROMs are mounted. Requests with a `rom_path` outside this directory are rejected. |
-| `PINE_SOCKET` | `/config/.XDG/pcsx2.sock` | Path to PCSX2's PINE IPC socket. Auto-discovered if not present at this path. |
-| `PINE_TIMEOUT` | `2.0` | Timeout (seconds) for connecting to and sending via the PINE socket. |
-| `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after sending the PINE command. Polling stops early once the write is detected. Increase for slow disks or large games. |
+| `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after sending the save keypress. Polling stops early once the write is detected. Increase for slow disks or large games. (Name kept for backwards compatibility — the broker now confirms writes for the xdotool save path, not PINE.) |
 | `SAVE_SLOT` | `10` | Default save state slot (1–10) for `/save-and-exit` when no `slot` is specified. Slot 10 is recommended as an auto-save slot, leaving 1–9 free for manual use. |
 | `SSTATE_DIR` | `/config/.config/PCSX2/sstates` | Where PCSX2 writes save state files. Currently informational — used by a planned RomM export/import feature. |
 
@@ -182,6 +180,49 @@ Save states are written to `SSTATE_DIR` as `{SERIAL} ({CRC}).{slot:02d}.p2s`.
 
 ---
 
+### `POST /save-state`
+
+Saves the current game to a slot without exiting. The keypress goes to the PCSX2 window via xdotool and the save runs in the background, so a `200` means the keystroke was sent — not that the write finished. Watch `/status` (`save_in_progress`) to confirm.
+
+```json
+{ "slot": 1 }
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `slot` | `1` | Save state slot (1–10) |
+
+```json
+{ "status": "saving", "slot": 1 }
+```
+
+- Returns `409` if no game is running or a save is already in progress
+- Returns `400` if `slot` is not an integer 1–10
+
+---
+
+### `POST /load-state`
+
+Loads a save state into the running game. This one blocks until the keystroke is dispatched.
+
+```json
+{ "slot": 1 }
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `slot` | `1` | Save state slot (1–10) |
+
+```json
+{ "status": "ok", "loaded": true, "slot": 1 }
+```
+
+- Returns `409` if no game is running
+- Returns `400` if `slot` is not an integer 1–10
+- Returns `503` if the PCSX2 window can't be reached (the broker itself is fine)
+
+---
+
 ### `POST /volume`
 
 Sets the audio output volume.
@@ -254,7 +295,7 @@ Expected on game launch:
 
 Expected on save-and-exit:
 ```
-14:25:45 [broker] INFO PINE: save command sent (slot 0) — waiting 3.0s for write
+14:25:45 [broker] INFO xdotool: F1 sent to window 0x3a00007 (slot 10) — waiting for write (max 20.0s)
 14:25:48 [broker] INFO Stopping PCSX2 (PID 123)...
 14:25:49 [broker] INFO Launching PCSX2 (rom=dashboard)
 14:25:49 [broker] INFO PCSX2 launched (PID 456)
@@ -287,8 +328,8 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 | Save state on exit | ✅ Done | `POST /save-and-exit` — xdotool F-key to PCSX2 window, slot 10 default |
 | Return to dashboard on exit | ✅ Done | Automatic after any exit path |
 | Volume control | ✅ Done | `POST /volume` and `POST /mute` via `pactl` |
-| Manual save state (no exit) | 🔜 Planned | `POST /save-state` with slot selection |
-| Manual load state | 🔜 Planned | `POST /load-state` with slot selection |
+| Manual save state (no exit) | ✅ Done | `POST /save-state` with slot selection |
+| Manual load state | ✅ Done | `POST /load-state` with slot selection |
 | RomM save state export/import | 🔜 Planned | Sync `.p2s` files from `SSTATE_DIR` to/from RomM library |
 
 ---

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ docker compose up -d --force-recreate pcsx2
 | `ROM_ROOT` | `/romm/library` | Root path inside the container where ROMs are mounted. Requests with a `rom_path` outside this directory are rejected. |
 | `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after sending the save keypress. Polling stops early once the write is detected. Increase for slow disks or large games. (Name kept for backwards compatibility — the broker now confirms writes for the xdotool save path, not PINE.) |
 | `SAVE_SLOT` | `10` | Default save state slot (1–10) for `/save-and-exit` when no `slot` is specified. Slot 10 is recommended as an auto-save slot, leaving 1–9 free for manual use. |
-| `SSTATE_DIR` | `/config/.config/PCSX2/sstates` | Where PCSX2 writes save state files. Currently informational — used by a planned RomM export/import feature. |
+| `SSTATE_DIR` | `/config/.config/PCSX2/sstates` | Where PCSX2 writes save state files. Served and written by the `/state-file` endpoints for RomM's save-state sync. |
+| `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish before serving the slot file. |
 
 ---
 
@@ -223,6 +224,34 @@ Loads a save state into the running game. This one blocks until the keystroke is
 
 ---
 
+### `GET /state-file?slot=N`
+
+Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centralized save-state sync. If a save is in flight the response blocks until the write completes (up to `STATE_GET_WAIT`, default 30 s), so a GET fired right after `/save-state` always carries the finished file.
+
+| Query param | Default | Description |
+|---|---|---|
+| `slot` | `0` | Save state slot (1–10); `0` resolves to `SAVE_SLOT` |
+
+- Response body is `application/octet-stream`; the emulator's own filename is echoed in the `X-State-Filename` header
+- Returns `404` if no state file exists for the slot
+- Returns `400` if `slot` is not an integer 0–10
+
+---
+
+### `PUT /state-file?filename=NAME`
+
+Writes a state file into the sstates directory, used by RomM to hydrate a freshly claimed container with the user's stored states. `NAME` is the filename a previous GET returned — written back verbatim so PCSX2 recognises the slot.
+
+- Body is the raw file content (`Content-Length` required, max 256 MB)
+- `NAME` must be a bare `.p2s` basename; path components are rejected
+- The write is atomic (temp file + rename) and the file is chowned to `abc` so PCSX2 can overwrite the slot later
+
+```json
+{ "status": "ok", "filename": "SLUS-12345 (ABCD1234).03.p2s" }
+```
+
+---
+
 ### `POST /volume`
 
 Sets the audio output volume.
@@ -330,7 +359,7 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 | Volume control | ✅ Done | `POST /volume` and `POST /mute` via `pactl` |
 | Manual save state (no exit) | ✅ Done | `POST /save-state` with slot selection |
 | Manual load state | ✅ Done | `POST /load-state` with slot selection |
-| RomM save state export/import | 🔜 Planned | Sync `.p2s` files from `SSTATE_DIR` to/from RomM library |
+| RomM save state export/import | ✅ Done | `GET`/`PUT /state-file` — RomM pulls saves into the library and hydrates slots on claim |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ docker compose up -d --force-recreate pcsx2
 | `SAVE_SLOT` | `10` | Default save state slot (1–10) for `/save-and-exit` when no `slot` is specified. Slot 10 is recommended as an auto-save slot, leaving 1–9 free for manual use. |
 | `SSTATE_DIR` | `/config/.config/PCSX2/sstates` | Where PCSX2 writes save state files. Served and written by the `/state-file` endpoints for RomM's save-state sync. |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish before serving the slot file. |
+| `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game VM to reach running state before giving up on the deferred state load. |
+| `RESUME_LOAD_SETTLE` | `3.0` | Seconds to let the game settle after the VM reports running, before the deferred `load_slot` state load fires. |
 
 ---
 
@@ -126,12 +128,13 @@ Returns `{"active": false, ...}` when no game is running.
 Kills any running game and launches a new ROM. Returns immediately; launch runs in a background thread.
 
 ```json
-{ "rom_path": "/romm/library/ps2/game.chd", "rom_name": "Game Title" }
+{ "rom_path": "/romm/library/ps2/game.chd", "rom_name": "Game Title", "load_slot": 3 }
 ```
 
 - `rom_path` must exist and be under `ROM_ROOT`
+- `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
 - Returns `409` if a save is in progress
-- Returns `400` if `rom_path` is missing or outside `ROM_ROOT`
+- Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10
 - Returns `422` if `rom_path` does not exist
 
 ```json

--- a/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
@@ -25,6 +25,23 @@ if [ ${#_pkgs[@]} -gt 0 ]; then
         || echo "[broker-mod] ERROR: failed to install ${_pkgs[*]}"
 fi
 
+# Ubuntu's +dfsg PCSX2 package strips patches.zip from the resources dir,
+# so every game boot warns "Built-in game patches are not available" and
+# titles that rely on compatibility patches misbehave. Fetch the official
+# archive from the PCSX2 project. Non-fatal if offline: games still run.
+PATCHES_ZIP="/usr/share/PCSX2/resources/patches.zip"
+if [ ! -s "$PATCHES_ZIP" ]; then
+    echo "[broker-mod] Downloading PCSX2 patches.zip..."
+    if curl -fsSL -o "$PATCHES_ZIP" \
+        "https://github.com/PCSX2/pcsx2_patches/releases/latest/download/patches.zip"; then
+        chmod 644 "$PATCHES_ZIP"
+        echo "[broker-mod] patches.zip installed."
+    else
+        rm -f "$PATCHES_ZIP"
+        echo "[broker-mod] WARNING: patches.zip download failed; built-in game patches unavailable."
+    fi
+fi
+
 # Lock down the sudoers rule so sudo accepts it (requires mode 0440).
 chmod 0440 /etc/sudoers.d/broker
 echo "[broker-mod] sudoers rule set."

--- a/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
@@ -32,16 +32,24 @@ echo "[broker-mod] Disabled labwc autostart."
 # Patch the selkies input_handler.py keep-alive loop to check reader.at_eof().
 # Without this, idle gamepad sockets never detect client disconnection because
 # asyncio buffers the EOF but writer.is_closing() never flips on Unix sockets.
-INPUT_HANDLER="/lsiopy/lib/python3.12/site-packages/selkies/input_handler.py"
+# Glob over the python version so the patch survives base image upgrades that
+# bump e.g. python3.12 → python3.13.
+INPUT_HANDLER=$(compgen -G "/lsiopy/lib/python3.*/site-packages/selkies/input_handler.py" | head -1)
+INPUT_HANDLER="${INPUT_HANDLER:-/lsiopy/lib/python3.12/site-packages/selkies/input_handler.py}"
 if [ -f "$INPUT_HANDLER" ]; then
     if grep -q "reader.at_eof()" "$INPUT_HANDLER"; then
         echo "[broker-mod] selkies input_handler.py EOF patch already applied."
     else
         sed -i \
             's/while self\.running and not writer\.is_closing():/while self.running and not writer.is_closing() and not reader.at_eof():/' \
-            "$INPUT_HANDLER" \
-            || echo "[broker-mod] ERROR: sed patch failed on input_handler.py"
-        echo "[broker-mod] Patched selkies input_handler.py EOF detection."
+            "$INPUT_HANDLER"
+        # Verify the substitution actually took — sed exits 0 even when the
+        # pattern never matched, so grep is the only honest success signal.
+        if grep -q "reader.at_eof()" "$INPUT_HANDLER"; then
+            echo "[broker-mod] Patched selkies input_handler.py EOF detection."
+        else
+            echo "[broker-mod] ERROR: input_handler.py EOF pattern not found — patch NOT applied (upstream may have changed)"
+        fi
     fi
 
     # Silence the selkies_gamepad logger — it emits ~80 INFO lines per launch cycle

--- a/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
@@ -7,9 +7,15 @@
 # breaks the hardcoded display expectations of the broker and stream.
 XDG_RUNTIME_DIR="/config/.XDG"
 mkdir -p "$XDG_RUNTIME_DIR"
-find "$XDG_RUNTIME_DIR" -name "wayland-*" -delete
-rm -rf /tmp/.X11-unix/X* /tmp/.X*lock
-echo "[broker-mod] Cleaned up stale display sockets."
+# Only clean when no display server is alive — if s6 ordering ever changes
+# and the compositor is already up, deleting its live socket kills the stream.
+if pgrep -x Xvfb >/dev/null || pgrep -x Xwayland >/dev/null || pgrep -x labwc >/dev/null; then
+    echo "[broker-mod] Display server already running — skipping socket cleanup."
+else
+    find "$XDG_RUNTIME_DIR" -name "wayland-*" -delete
+    rm -rf /tmp/.X11-unix/X* /tmp/.X*lock
+    echo "[broker-mod] Cleaned up stale display sockets."
+fi
 
 # Ensure python3 is available for the broker service, and libshaderc for
 # PCSX2's Vulkan renderer — the base image ships without it, so on a host
@@ -35,7 +41,9 @@ if [ ! -s "$PATCHES_ZIP" ]; then
     # Download to a temp path and verify it is a well-formed zip before
     # installing — the release URL floats ("latest"), so a checksum can't be
     # pinned, but a truncated or non-zip response must never land in place.
-    if curl -fsSL -o "$PATCHES_ZIP.tmp" \
+    # Bounded so an unresponsive GitHub can't stall container init for an
+    # optional file.
+    if curl -fsSL --connect-timeout 10 --max-time 60 -o "$PATCHES_ZIP.tmp" \
         "https://github.com/PCSX2/pcsx2_patches/releases/latest/download/patches.zip" \
         && python3 -c 'import sys, zipfile
 with zipfile.ZipFile(sys.argv[1]) as z:

--- a/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
@@ -32,13 +32,21 @@ fi
 PATCHES_ZIP="/usr/share/PCSX2/resources/patches.zip"
 if [ ! -s "$PATCHES_ZIP" ]; then
     echo "[broker-mod] Downloading PCSX2 patches.zip..."
-    if curl -fsSL -o "$PATCHES_ZIP" \
-        "https://github.com/PCSX2/pcsx2_patches/releases/latest/download/patches.zip"; then
-        chmod 644 "$PATCHES_ZIP"
+    # Download to a temp path and verify it is a well-formed zip before
+    # installing — the release URL floats ("latest"), so a checksum can't be
+    # pinned, but a truncated or non-zip response must never land in place.
+    if curl -fsSL -o "$PATCHES_ZIP.tmp" \
+        "https://github.com/PCSX2/pcsx2_patches/releases/latest/download/patches.zip" \
+        && python3 -c 'import sys, zipfile
+with zipfile.ZipFile(sys.argv[1]) as z:
+    sys.exit(1 if z.testzip() is not None or not z.namelist() else 0)' \
+            "$PATCHES_ZIP.tmp" 2>/dev/null; then
+        chmod 644 "$PATCHES_ZIP.tmp"
+        mv "$PATCHES_ZIP.tmp" "$PATCHES_ZIP"
         echo "[broker-mod] patches.zip installed."
     else
-        rm -f "$PATCHES_ZIP"
-        echo "[broker-mod] WARNING: patches.zip download failed; built-in game patches unavailable."
+        rm -f "$PATCHES_ZIP.tmp"
+        echo "[broker-mod] WARNING: patches.zip download failed or corrupt; built-in game patches unavailable."
     fi
 fi
 

--- a/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-pcsx2-config/init.sh
@@ -11,11 +11,18 @@ find "$XDG_RUNTIME_DIR" -name "wayland-*" -delete
 rm -rf /tmp/.X11-unix/X* /tmp/.X*lock
 echo "[broker-mod] Cleaned up stale display sockets."
 
-# Ensure python3 is available for the broker service.
-if ! command -v python3 &>/dev/null; then
-    echo "[broker-mod] Installing python3..."
-    apt-get update -qq && apt-get install -y -qq python3 \
-        || echo "[broker-mod] ERROR: failed to install python3"
+# Ensure python3 is available for the broker service, and libshaderc for
+# PCSX2's Vulkan renderer — the base image ships without it, so on a host
+# with a GPU the GS device fails shader compilation and pcsx2-qt exits
+# within a second of booting any game (the gameless dashboard never
+# initializes GS, masking the breakage until a game is launched).
+_pkgs=()
+command -v python3 &>/dev/null || _pkgs+=(python3)
+ldconfig -p | grep -q libshaderc.so.1 || _pkgs+=(libshaderc1)
+if [ ${#_pkgs[@]} -gt 0 ]; then
+    echo "[broker-mod] Installing: ${_pkgs[*]}"
+    apt-get update -qq && apt-get install -y -qq "${_pkgs[@]}" \
+        || echo "[broker-mod] ERROR: failed to install ${_pkgs[*]}"
 fi
 
 # Lock down the sudoers rule so sudo accepts it (requires mode 0440).

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -8,11 +8,10 @@ import logging
 import os
 import signal
 import socket as _socket
-import struct
 import subprocess
 import sys
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread, Lock
 
@@ -110,9 +109,8 @@ ENV = {
 
 INI_PATH = Path("/config/.config/PCSX2/inis/PCSX2.ini")
 
-# PCSX2 2.x creates the PINE socket as pcsx2.sock (not pcsx2-{slot})
-PINE_SOCKET  = Path(os.environ.get("PINE_SOCKET", str(Path(ENV["XDG_RUNTIME_DIR"]) / "pcsx2.sock")))
-PINE_TIMEOUT = float(os.environ.get("PINE_TIMEOUT", "2.0"))   # connect + send timeout
+# Env var name kept as PINE_WAIT for backwards compatibility with existing
+# deployments; it now bounds the xdotool save-state write poll.
 PINE_WAIT    = float(os.environ.get("PINE_WAIT",   "20.0"))   # max seconds to poll for write completion
 SAVE_SLOT    = int(os.environ.get("SAVE_SLOT", "10"))
 SSTATE_DIR   = Path(os.environ.get("SSTATE_DIR", "/config/.config/PCSX2/sstates"))
@@ -139,6 +137,11 @@ if not _LD_PRELOAD_FROM_ENV:
 # errors are visible after the fact. /config is the only host-mapped writable
 # path we can rely on.
 PCSX2_LOG_PATH = Path(os.environ.get("PCSX2_LOG_PATH", "/config/pcsx2-qt.log"))
+
+# UID/GID to chown the log to; defaults to the linuxserver abc user but honors
+# PUID/PGID overrides so pcsx2-qt can still write it on a remapped container.
+_LOG_UID = int(os.environ.get("PUID", "1000"))
+_LOG_GID = int(os.environ.get("PGID", "1000"))
 
 # ── Session state ─────────────────────────────────────────────────────────────
 
@@ -290,7 +293,10 @@ def _kill_pcsx2():
         except subprocess.TimeoutExpired:
             log.warning("PCSX2 did not exit after SIGTERM — sending SIGKILL")
             os.killpg(pgid, signal.SIGKILL)
-            proc.wait()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                log.error("PCSX2 did not exit after SIGKILL — giving up")
     except ProcessLookupError:
         pass  # already gone
 
@@ -317,7 +323,7 @@ def _launch_pcsx2_internal(rom_path):
     try:
         log_fh = open(PCSX2_LOG_PATH, "ab", buffering=0)
         try:
-            os.chown(PCSX2_LOG_PATH, 1000, 1000)  # abc uid/gid in linuxserver images
+            os.chown(PCSX2_LOG_PATH, _LOG_UID, _LOG_GID)
         except (OSError, PermissionError):
             pass
         log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} launch (rom={rom_path or 'dashboard'}) ===\n".encode())
@@ -462,30 +468,10 @@ def _launch_pcsx2(rom_path):
     _launch_pcsx2_internal(rom_path)
 
 
-def _find_pine_socket() -> Path | None:
-    """Locate PCSX2's PINE Unix socket. Tries the configured path first, then
-    falls back to a glob search so the correct name is discovered automatically."""
-    if PINE_SOCKET.exists():
-        return PINE_SOCKET
-    runtime_dir = Path(ENV["XDG_RUNTIME_DIR"])
-    for pattern in ("pcsx2-*", "pcsx2.sock"):
-        found = sorted(runtime_dir.glob(pattern))
-        if found:
-            log.debug("PINE: configured path %s absent — using %s", PINE_SOCKET, found[0])
-            return found[0]
-    for pattern in ("pcsx2-*", "pcsx2.sock"):
-        found = sorted(Path("/tmp").glob(pattern))
-        if found:
-            log.debug("PINE: found socket in /tmp at %s", found[0])
-            return found[0]
-    log.error("PINE: no socket found (looked in %s and /tmp)", runtime_dir)
-    return None
-
-
 def _sstate_snapshot() -> dict:
     """Return {Path: (size, mtime)} for every .p2s file currently in SSTATE_DIR."""
     if not SSTATE_DIR.is_dir():
-        log.debug("PINE: SSTATE_DIR absent — %s", SSTATE_DIR)
+        log.debug("Save: SSTATE_DIR absent — %s", SSTATE_DIR)
         return {}
     snap = {}
     for p in SSTATE_DIR.glob("*.p2s"):
@@ -494,7 +480,7 @@ def _sstate_snapshot() -> dict:
             snap[p] = (st.st_size, st.st_mtime)
         except OSError:
             pass
-    log.debug("PINE: snapshot — %d file(s) in %s", len(snap), SSTATE_DIR)
+    log.debug("Save: snapshot — %d file(s) in %s", len(snap), SSTATE_DIR)
     return snap
 
 
@@ -524,10 +510,10 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
                     target = p
                     last_size = size
                     stable_since = time.monotonic()
-                    log.debug("PINE: write detected — %s (%d bytes, mtime %.3f)", p.name, size, mtime)
+                    log.debug("Save: write detected — %s (%d bytes, mtime %.3f)", p.name, size, mtime)
                     break
                 else:
-                    log.debug("PINE: %s unchanged (mtime %.3f)", p.name, mtime)
+                    log.debug("Save: %s unchanged (mtime %.3f)", p.name, mtime)
         else:
             cur = after.get(target)
             if cur is None:
@@ -540,7 +526,7 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
                     stable_since = time.monotonic()
                 elif time.monotonic() - stable_since >= STABLE_SECS:  # type: ignore[operator]
                     log.info(
-                        "PINE: save state write complete — %s (%d bytes) in %.1fs",
+                        "Save: state write complete — %s (%d bytes) in %.1fs",
                         target.name, last_size,
                         time.monotonic() - start,
                     )
@@ -549,59 +535,6 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
         time.sleep(POLL_SECS)
 
     return False
-
-
-def _pine_save_state(slot: int) -> bool:
-    """Send MsgSaveState (opcode 9) to PCSX2 via the PINE Unix socket.
-
-    Wire format: [uint32 LE: payload length] [0x09] [slot byte]
-
-    Confirmed behaviour in PCSX2 2.6.3: the command is received and the save
-    state file IS written to SSTATE_DIR, but PCSX2 never sends a socket
-    response for any PINE opcode. The write can take 10–20 s for large games.
-    We close the socket immediately after sending and poll SSTATE_DIR for up
-    to PINE_WAIT seconds (default 20 s), stopping as soon as the write
-    stabilises.
-
-    Returns True if the command was successfully sent.
-    """
-    socket_path = _find_pine_socket()
-    if socket_path is None:
-        return False
-
-    before = _sstate_snapshot()
-
-    # MsgSaveState opcode = 9 per PCSX2 PINE IPC spec (pcsx2/PINE.cpp)
-    payload = bytes([9, slot & 0xFF])
-    msg = struct.pack("<I", len(payload)) + payload
-    try:
-        with _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM) as s:
-            s.settimeout(PINE_TIMEOUT)
-            s.connect(str(socket_path))
-            s.sendall(msg)
-            # Keep the socket open while polling — PCSX2 only processes the
-            # command (and writes the save file) while the connection is alive.
-            # It attempts to write a response; closing early causes EPIPE and
-            # aborts the save.
-            log.info("PINE: save command sent (slot %d) — waiting for write (max %.1fs)", slot, PINE_WAIT)
-            deadline = time.monotonic() + PINE_WAIT
-            ok = _wait_for_sstate_write(before, deadline)
-    except FileNotFoundError:
-        log.error("PINE save state (slot %d): socket %s vanished between discovery and connect", slot, socket_path)
-        return False
-    except ConnectionRefusedError:
-        log.error("PINE save state (slot %d): connection refused on %s — PCSX2 may have just exited", slot, socket_path)
-        return False
-    except _socket.timeout:
-        log.error("PINE save state (slot %d): timed out (>%.1fs) connecting/sending to %s", slot, PINE_TIMEOUT, socket_path)
-        return False
-    except OSError as exc:
-        log.error("PINE save state (slot %d): %s on %s (errno=%s)", slot, type(exc).__name__, socket_path, exc.errno)
-        return False
-
-    if not ok:
-        log.warning("PINE: save state write not detected within %.1fs — proceeding anyway", PINE_WAIT)
-    return True
 
 
 _XDOTOOL_ENV = {
@@ -832,11 +765,20 @@ _PACTL_CMD = [
 
 
 def _pactl(*args: str) -> subprocess.CompletedProcess:
-    """Run pactl as abc so it connects to abc's PulseAudio instance."""
-    return subprocess.run(
-        _PACTL_CMD + ["pactl"] + list(args),
-        capture_output=True, text=True, timeout=5,
-    )
+    """Run pactl as abc so it connects to abc's PulseAudio instance.
+
+    A hung or missing pactl is reported as a non-zero CompletedProcess (rather
+    than raising) so the /volume and /mute handlers return a 500 instead of
+    dropping the connection with an unhandled exception."""
+    cmd = _PACTL_CMD + ["pactl"] + list(args)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    except subprocess.TimeoutExpired:
+        log.error("pactl timed out: %s", " ".join(args))
+        return subprocess.CompletedProcess(cmd, 124, "", "pactl timed out")
+    except OSError as exc:
+        log.error("pactl failed to run: %s", exc)
+        return subprocess.CompletedProcess(cmd, 127, "", str(exc))
 
 
 def _pactl_get_volume() -> int | None:
@@ -858,6 +800,8 @@ def _pactl_get_mute() -> bool | None:
     """Return current mute state as bool, or None on error."""
     result = _pactl("get-sink-mute", "@DEFAULT_SINK@")
     if result.returncode != 0:
+        log.error("pactl get-sink-mute failed (rc=%s): %s",
+                  result.returncode, result.stderr.strip())
         return None
     return result.stdout.strip().endswith("yes")
 
@@ -888,7 +832,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
     def _read_body(self) -> dict:
         try:
-            length = min(int(self.headers.get("Content-Length", 0)), 64 * 1024)
+            length = max(0, min(int(self.headers.get("Content-Length", 0)), 64 * 1024))
         except ValueError:
             length = 0
         if length == 0:
@@ -1022,10 +966,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 _session["save_in_progress"] = True
             body = self._read_body()
             slot = body.get("slot", 1)
-            if not isinstance(slot, int) or not (1 <= slot <= 9):
+            if not isinstance(slot, int) or not (1 <= slot <= 10):
                 with _session_lock:
                     _session["save_in_progress"] = False
-                self._send_json(400, {"error": "slot must be 1–9"})
+                self._send_json(400, {"error": "slot must be 1–10"})
                 return
             def _bg_save(s):
                 try:
@@ -1163,10 +1107,15 @@ def main():
     _patch_ini()
     _launch_pcsx2_internal(None)
 
-    server = HTTPServer(("0.0.0.0", PORT), BrokerHandler)
+    # ThreadingHTTPServer: /save-and-exit with wait=true blocks its handler for
+    # up to PINE_WAIT seconds; a single-threaded server would stall /health and
+    # /status for the duration. Session state is already lock-protected.
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), BrokerHandler)
     log.info("ROM broker listening on port %d", PORT)
     if SECRET:
         log.info("Shared secret auth enabled")
+    else:
+        log.warning("BROKER_SECRET not set — all POST/DELETE endpoints are unauthenticated")
 
     # Install a single handler for both SIGTERM (systemd stop) and SIGINT
     # (Ctrl-C). We intentionally don't use server.serve_forever()'s default

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -116,6 +116,11 @@ PINE_WAIT    = float(os.environ.get("PINE_WAIT",   "20.0"))   # max seconds to p
 SAVE_SLOT    = int(os.environ.get("SAVE_SLOT", "10"))
 SSTATE_DIR   = Path(os.environ.get("SSTATE_DIR", "/config/.config/PCSX2/sstates"))
 
+# Resume-from-state (launch with load_slot): how long to wait for the game VM
+# to come up, and how long to let it settle before the deferred slot load.
+RESUME_LOAD_WAIT   = float(os.environ.get("RESUME_LOAD_WAIT",   "90.0"))
+RESUME_LOAD_SETTLE = float(os.environ.get("RESUME_LOAD_SETTLE", "3.0"))
+
 logging.basicConfig(
     level=getattr(logging, os.environ.get("BROKER_LOG_LEVEL", "INFO").upper(), logging.INFO),
     format="%(asctime)s [broker] %(levelname)s %(message)s",
@@ -601,6 +606,7 @@ PINE_SOCKET = Path(XDG_RUNTIME_DIR) / "pcsx2.sock"
 
 _PINE_MSG_SAVE_STATE = 0x09
 _PINE_MSG_LOAD_STATE = 0x0A
+_PINE_MSG_EMU_STATUS = 0x0F
 
 
 def _pine_recv_exact(sock: _socket.socket, n: int) -> bytes | None:
@@ -680,6 +686,35 @@ def _load_state(slot: int) -> bool:
         return True
     log.warning("PINE unavailable — falling back to xdotool F-key delivery")
     return _xdotool_load_state(slot)
+
+
+def _pine_emu_status() -> int | None:
+    """VM status via PINE: 0 running, 1 paused, 2 shutdown. None if PINE is down."""
+    body = _pine_request(_PINE_MSG_EMU_STATUS, timeout=2.0)
+    if body is None or len(body) < 4:
+        return None
+    return struct.unpack("<I", body[:4])[0]
+
+
+def _deferred_load_state(slot: int) -> None:
+    """Resume-from-state: load `slot` once the freshly launched game's VM is up.
+
+    Waits for the launch to finish swapping instances before trusting the
+    status probe — probing earlier could see a still-running previous game
+    and load the slot into the wrong VM. After the swap, only the new game
+    VM reports running (a gameless relaunch reports shutdown).
+    """
+    deadline = time.monotonic() + RESUME_LOAD_WAIT
+    while time.monotonic() < deadline:
+        with _session_lock:
+            launching = _session["launch_in_progress"]
+        if not launching and _pine_emu_status() == 0:
+            time.sleep(RESUME_LOAD_SETTLE)
+            ok = _load_state(slot)
+            log.info("resume: deferred load of slot %d %s", slot, "delivered" if ok else "failed")
+            return
+        time.sleep(1.0)
+    log.warning("resume: VM never reached running state — slot %d not loaded", slot)
 
 
 _XDOTOOL_ENV = {
@@ -1265,6 +1300,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(422, {"error": "rom_path does not exist", "path": str(rom_path)})
             return
 
+        # Resume-from-state: load this slot once the game VM is up.
+        load_slot = body.get("load_slot")
+        if load_slot is not None and (
+            not isinstance(load_slot, int) or not (1 <= load_slot <= 10)
+        ):
+            self._send_json(400, {"error": "load_slot must be 1–10"})
+            return
+
         # Check save_in_progress and claim launch_in_progress in the same lock
         # acquisition — checking them separately lets a save start in the gap,
         # and the launch would then kill PCSX2 mid-savestate.
@@ -1280,6 +1323,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
         Thread(
             target=_launch_pcsx2, args=(str(rom_path), True), daemon=True
         ).start()
+        if load_slot is not None:
+            Thread(
+                target=_deferred_load_state, args=(load_slot,), daemon=True
+            ).start()
         self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
 
     def do_DELETE(self):

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import shutil
 import signal
 import socket as _socket
 import struct
@@ -1136,6 +1137,149 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
     return (written, skipped)
 
 
+# ── Whole memory-card sync (per-user card model) ──────────────────────────────
+# Distinct from the /save-file mtime-merge path above: /memory-card ships and
+# replaces the ENTIRE Slot-1 folder card (superblock + every game folder) as one
+# host-independent image, so a user's card can be hydrated onto any pooled
+# container. GET evacuates the whole card; PUT wipes Slot 1 and lays the card
+# back down. Only Slot 1 is ever touched — Slot 2 is never synced.
+
+
+def _memcards_dir() -> Path:
+    return (_save_data_root() or _SAVE_DATA_ROOTS[0]) / "memcards"
+
+
+def _slot1_filename() -> str | None:
+    """Read [MemoryCards] Slot1_Filename from PCSX2.ini (manual parse, matching
+    _read_initial_save_slot). Returns the configured card name, or None."""
+    if not INI_PATH.exists():
+        return None
+    try:
+        section = ""
+        for raw in INI_PATH.read_text().splitlines():
+            line = raw.strip()
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1]
+                continue
+            if section != "MemoryCards":
+                continue
+            if line.replace(" ", "").startswith("Slot1_Filename="):
+                _, _, value = line.partition("=")
+                return value.strip() or None
+    except OSError as exc:
+        log.debug("Could not read Slot1_Filename from PCSX2.ini: %s", exc)
+    return None
+
+
+def _slot1_card_path() -> Path | None:
+    """Absolute path to the Slot-1 memory card, existence-independent. None when
+    no Slot1_Filename is configured. A folder card is a DIRECTORY at this path; a
+    File card is a regular .ps2 file (rejected by the whole-card sync). The INI
+    value is a card name, so only its basename is honoured."""
+    name = _slot1_filename()
+    if not name:
+        return None
+    return _memcards_dir() / Path(name).name
+
+
+def _build_memory_card_archive() -> bytes | None | str:
+    """Zip the entire Slot-1 folder card, member paths relative to the card root
+    so the image is card-name independent. Returns the zip bytes, None when
+    Slot 1 has no folder card, or an error string when it is a File card."""
+    path = _slot1_card_path()
+    if path is None:
+        return None
+    if path.exists() and not path.is_dir():
+        return "slot 1 is a File memory card; a Folder card is required"
+    if not path.is_dir():
+        return None
+    files = [p for p in sorted(path.rglob("*")) if p.is_file() and not p.is_symlink()]
+    total = 0
+    for p in files:
+        try:
+            total += p.stat().st_size
+        except OSError:
+            continue
+    if total > SAVE_FILE_MAX_BYTES:
+        log.warning("memory-card: card exceeds size limit (%d bytes)", total)
+        return "memory card exceeds size limit"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in files:
+            try:
+                zf.write(p, p.relative_to(path).as_posix())
+            except OSError as exc:
+                log.warning("memory-card: could not read %s — %s", p, exc)
+    return buf.getvalue()
+
+
+def _replace_memory_card(content: bytes) -> tuple[int] | str:
+    """Wipe the Slot-1 folder card and lay down the pulled card image. Returns
+    (written,) on success or an error string. The whole card is replaced (no
+    per-file mtime merge): this is the hydrate-with-isolation guarantee for
+    pooled containers. Extraction goes to a staging dir that is swapped over the
+    live card, so a mid-way failure never leaves a half-wiped card."""
+    path = _slot1_card_path()
+    if path is None:
+        return "no Slot 1 memory card configured in PCSX2.ini"
+    if path.exists() and not path.is_dir():
+        # This container is misprovisioned: hydrate needs a Folder card in slot 1.
+        # Log loudly so the offending host surfaces in monitoring, then refuse.
+        log.warning(
+            "memory-card: hydrate rejected on %s — slot 1 is a File card at %s",
+            _socket.gethostname(),
+            path,
+        )
+        return "slot 1 is a File memory card; a Folder card is required"
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        return "body is not a zip archive"
+    with zf:
+        infos = [i for i in zf.infolist() if not i.is_dir()]
+        if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
+            return "archive exceeds size limit when extracted"
+        for info in infos:
+            member = PurePosixPath(info.filename)
+            if member.is_absolute() or ".." in member.parts:
+                return f"archive member escapes card dir: {info.filename}"
+
+        parent = path.parent
+        staging = parent / f".{path.name}.new-{os.getpid()}"
+        backup = parent / f".{path.name}.old-{os.getpid()}"
+        shutil.rmtree(staging, ignore_errors=True)
+        try:
+            _mkdirs_owned(staging)
+            written = 0
+            for info in infos:
+                target = staging / PurePosixPath(info.filename)
+                _mkdirs_owned(target.parent)
+                tmp = target.parent / f".{target.name}.tmp"
+                tmp.write_bytes(zf.read(info))
+                os.chown(tmp, _LOG_UID, _LOG_GID)
+                os.replace(tmp, target)
+                written += 1
+            # Swap staging over the live card: move the old card aside, move the
+            # new one into place, then drop the old. Both live under memcards/,
+            # so the renames are atomic same-filesystem operations.
+            if path.exists():
+                os.replace(path, backup)
+            os.replace(staging, path)
+        except OSError as exc:
+            shutil.rmtree(staging, ignore_errors=True)
+            # If we moved the old card aside but never put the new one in place,
+            # restore it so a mid-swap failure never leaves the user cardless.
+            if not path.exists() and backup.exists():
+                try:
+                    os.replace(backup, path)
+                except OSError:
+                    log.error("memory-card: could not restore card to %s", path)
+            return f"could not write memory card: {exc}"
+        finally:
+            shutil.rmtree(backup, ignore_errors=True)
+    return (written,)
+
+
 # ── HTTP handler ──────────────────────────────────────────────────────────────
 
 class BrokerHandler(BaseHTTPRequestHandler):
@@ -1251,6 +1395,46 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
         self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
 
+    def _get_memory_card(self):
+        result = _build_memory_card_archive()
+        if isinstance(result, str):
+            # e.g. slot 1 is a File card, not a Folder card.
+            self._send_json(409, {"error": result})
+            return
+        if result is None:
+            self._send_json(404, {"error": "no folder memory card in slot 1"})
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/zip")
+        self.send_header("Content-Length", str(len(result)))
+        self.send_header("X-Memory-Card-Slot", "1")
+        self.end_headers()
+        self.wfile.write(result)
+        log.info("memory-card: served slot-1 card (%d bytes)", len(result))
+
+    def _put_memory_card(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or empty body"})
+            return
+        if length > SAVE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "archive too large"})
+            return
+        content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
+        result = _replace_memory_card(content)
+        if isinstance(result, str):
+            self._send_json(400, {"error": result})
+            return
+        (written,) = result
+        log.info("memory-card: replaced slot-1 card — %d files", written)
+        self._send_json(200, {"status": "ok", "written": written})
+
     def do_PUT(self):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
@@ -1258,6 +1442,9 @@ class BrokerHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         if parsed.path == "/save-file":
             self._put_save_file()
+            return
+        if parsed.path == "/memory-card":
+            self._put_memory_card()
             return
         if parsed.path != "/state-file":
             self._send_json(404, {"error": "not found"})
@@ -1314,6 +1501,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._get_state_file()
         elif urlparse(self.path).path == "/save-file":
             self._get_save_file()
+        elif urlparse(self.path).path == "/memory-card":
+            self._get_memory_card()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -153,6 +153,7 @@ _session: dict = {
     "started_at":       None,
     "is_managed":       False,
     "save_in_progress": False,
+    "launch_in_progress": False,  # guards against concurrent /launch requests
     "current_slot":     1,      # tracks PCSX2's active save state slot (resets to 1 on each launch)
 }
 
@@ -452,20 +453,26 @@ def _wait_for_no_pcsx2(timeout: float = 3.0) -> bool:
 
 
 def _launch_pcsx2(rom_path):
-    _kill_pcsx2()
-    _drain_gamepad_sockets()
-    _patch_ini()
-    if not _wait_for_no_pcsx2():
-        log.warning("pcsx2-qt still running after kill+drain; relaunching anyway")
-    with _session_lock:
-        _session["rom_path"] = rom_path
-        _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
-        # Only stamp a session start when an actual ROM is being played. The
-        # dashboard is an idle state.
-        _session["started_at"] = (
-            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
-        )
-    _launch_pcsx2_internal(rom_path)
+    try:
+        _kill_pcsx2()
+        _drain_gamepad_sockets()
+        _patch_ini()
+        if not _wait_for_no_pcsx2():
+            log.warning("pcsx2-qt still running after kill+drain; relaunching anyway")
+        with _session_lock:
+            _session["rom_path"] = rom_path
+            _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
+            # Only stamp a session start when an actual ROM is being played. The
+            # dashboard is an idle state.
+            _session["started_at"] = (
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
+            )
+        _launch_pcsx2_internal(rom_path)
+    finally:
+        # Release the /launch claim. Harmless no-op for dashboard relaunches
+        # that never set it.
+        with _session_lock:
+            _session["launch_in_progress"] = False
 
 
 def _sstate_snapshot() -> dict:
@@ -826,7 +833,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(payload)
 
@@ -845,6 +851,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
+        elif not self._check_secret():
+            # /health stays open for container healthchecks; all other GETs
+            # require the shared secret, matching POST/DELETE.
+            self._send_json(403, {"error": "forbidden"})
         elif self.path == "/status":
             with _session_lock:
                 active = (
@@ -1011,11 +1021,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "not found"})
             return
 
-        with _session_lock:
-            if _session["save_in_progress"]:
-                self._send_json(409, {"error": "save in progress"})
-                return
-
         body = self._read_body()
         raw_path = body.get("rom_path", "").strip()
 
@@ -1034,6 +1039,18 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(422, {"error": "rom_path does not exist", "path": str(rom_path)})
             return
 
+        # Check save_in_progress and claim launch_in_progress in the same lock
+        # acquisition — checking them separately lets a save start in the gap,
+        # and the launch would then kill PCSX2 mid-savestate.
+        with _session_lock:
+            if _session["save_in_progress"]:
+                self._send_json(409, {"error": "save in progress"})
+                return
+            if _session["launch_in_progress"]:
+                self._send_json(409, {"error": "launch already in progress"})
+                return
+            _session["launch_in_progress"] = True
+
         Thread(target=_launch_pcsx2, args=(str(rom_path),), daemon=True).start()
         self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
 
@@ -1048,13 +1065,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
         Thread(target=_launch_pcsx2, args=(None,), daemon=True).start()
         log.info("Soft reset: returning to dashboard")
         self._send_json(200, {"status": "resetting"})
-
-    def do_OPTIONS(self):
-        self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Broker-Secret")
-        self.end_headers()
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -1034,14 +1034,24 @@ def _save_data_root() -> Path | None:
 
 def _iter_save_files(root: Path) -> list[Path]:
     """Every regular file under the allowed save subtrees, sorted for a
-    deterministic archive (identical content zips to identical bytes)."""
+    deterministic archive (identical content zips to identical bytes).
+
+    Dot-prefixed path components are excluded: the memory-card swap keeps
+    its staging/backup/tmp entries (.Card.new-*, .Card.old-*, .*.tmp) inside
+    memcards/, and those must never be swept into a save archive."""
     files: list[Path] = []
     for sub in SAVE_SYNC_SUBTREES:
         base = root / sub
         if not base.is_dir():
             continue
         files.extend(
-            p for p in sorted(base.rglob("*")) if p.is_file() and not p.is_symlink()
+            p
+            for p in sorted(base.rglob("*"))
+            if p.is_file()
+            and not p.is_symlink()
+            and not any(
+                part.startswith(".") for part in p.relative_to(base).parts
+            )
         )
     return files
 
@@ -1072,15 +1082,17 @@ def _read_file_stable(
     return None
 
 
-def _build_save_archive(baseline: float) -> tuple[bytes, int] | None | str:
+def _build_save_archive(baseline: float) -> tuple[bytes | None, int] | None | str:
     """Zip every save file modified since the last game launch.
 
     Returns (zip_bytes, skipped) — `skipped` counts files left out because
-    they were unreadable or still being written — None when there is nothing
-    to sync (no data dir yet, or no file changed since `baseline`), or an
-    error string when the changed set exceeds the size limit. Member paths
-    are relative to the data dir so a later PUT restores them regardless of
-    which candidate dir is live."""
+    they were unreadable or still being written; zip_bytes is None when
+    every changed file was skipped, so the caller can refuse the pull
+    instead of serving an empty archive as a clean sync. Returns None when
+    there is nothing to sync (no data dir yet, or no file changed since
+    `baseline`), or an error string when the changed set exceeds the size
+    limit. Member paths are relative to the data dir so a later PUT
+    restores them regardless of which candidate dir is live."""
     root = _save_data_root()
     if root is None:
         log.debug("save-file: no PCSX2 data dir found")
@@ -1102,6 +1114,7 @@ def _build_save_archive(baseline: float) -> tuple[bytes, int] | None | str:
         return f"changed saves exceed size limit ({total} bytes)"
     buf = io.BytesIO()
     skipped = 0
+    wrote = 0
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for p in changed:
             result = _read_file_stable(p)
@@ -1114,6 +1127,9 @@ def _build_save_archive(baseline: float) -> tuple[bytes, int] | None | str:
                 date_time=time.localtime(mtime)[:6],
             )
             zf.writestr(info, data, zipfile.ZIP_DEFLATED)
+            wrote += 1
+    if wrote == 0:
+        return None, skipped
     return buf.getvalue(), skipped
 
 
@@ -1431,6 +1447,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(413, {"error": result})
             return
         archive, unstable = result
+        if archive is None:
+            # Every changed file was mid-write; refuse rather than serve an
+            # empty archive the caller would record as a clean sync.
+            self._send_json(
+                503,
+                {"error": "save files are still being written; retry shortly"},
+            )
+            return
         # Header values must be latin-1; ROM stems can be anything.
         safe_name = "".join(
             c for c in (rom_name or "pcsx2") if c.isascii() and c.isprintable()
@@ -1606,13 +1630,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
             return
+        path = urlparse(self.path).path
 
-        if self.path == "/cleanup":
+        if path == "/cleanup":
             Thread(target=_cleanup_sockets, daemon=True).start()
             self._send_json(200, {"status": "cleanup started"})
             return
 
-        if self.path == "/save-and-exit":
+        if path == "/save-and-exit":
             with _session_lock:
                 if _session["rom_path"] is None:
                     self._send_json(409, {"error": "no game is running"})
@@ -1671,7 +1696,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 self._send_json(200, {"status": "queued", "slot": slot})
             return
 
-        if self.path == "/volume":
+        if path == "/volume":
             body = self._read_body()
             if body is None:
                 return
@@ -1687,7 +1712,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"status": "ok", "level": level})
             return
 
-        if self.path == "/mute":
+        if path == "/mute":
             body = self._read_body()
             if body is None:
                 return
@@ -1704,7 +1729,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"status": "ok", "mute": mute_state})
             return
 
-        if self.path == "/save-state":
+        if path == "/save-state":
             with _session_lock:
                 if _session["rom_path"] is None:
                     self._send_json(409, {"error": "no game is running"})
@@ -1736,7 +1761,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"status": "saving", "slot": slot})
             return
 
-        if self.path == "/load-state":
+        if path == "/load-state":
             with _session_lock:
                 if _session["rom_path"] is None:
                     self._send_json(409, {"error": "no game is running"})
@@ -1762,7 +1787,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 })
             return
 
-        if self.path != "/launch":
+        if path != "/launch":
             self._send_json(404, {"error": "not found"})
             return
 
@@ -1819,7 +1844,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
             return
-        if self.path != "/launch":
+        if urlparse(self.path).path != "/launch":
             self._send_json(404, {"error": "not found"})
             return
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -15,6 +15,7 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread, Lock
+from urllib.parse import parse_qs, urlparse
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -553,6 +554,42 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
     return False
 
 
+# ── State file transfer ───────────────────────────────────────────────────────
+# RomM's backend syncs save states through these helpers: after a save it
+# GETs the freshly written slot file, and on session claim it PUTs the user's
+# stored states back into SSTATE_DIR. GET blocks while a save is in flight so
+# the response always carries the completed write.
+
+STATE_FILE_MAX_BYTES = 256 * 1024 * 1024
+STATE_GET_WAIT = float(os.environ.get("STATE_GET_WAIT", "30.0"))
+
+
+def _wait_for_save_idle(deadline: float) -> None:
+    """Block until no save is in flight, or the deadline passes."""
+    while time.monotonic() < deadline:
+        with _session_lock:
+            if not _session["save_in_progress"]:
+                return
+        time.sleep(0.2)
+
+
+def _newest_state_for_slot(slot: int) -> Path | None:
+    """Newest .p2s for the slot. PCSX2 names states `{serial} ({crc}).{slot:02d}.p2s`;
+    the bare-suffix glob covers older unpadded names."""
+    if not SSTATE_DIR.is_dir():
+        return None
+    candidates: list[tuple[float, Path]] = []
+    for pattern in {f"*.{slot:02d}.p2s", f"*.{slot}.p2s"}:
+        for p in SSTATE_DIR.glob(pattern):
+            try:
+                candidates.append((p.stat().st_mtime, p))
+            except OSError:
+                pass
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
 # ── PINE IPC ──────────────────────────────────────────────────────────────────
 # PCSX2's native IPC protocol. _patch_ini enables it (EnablePINE = true) and
 # pcsx2-qt listens on a unix socket in XDG_RUNTIME_DIR. Used as the primary
@@ -949,6 +986,92 @@ class BrokerHandler(BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             return {}
 
+    def _get_state_file(self):
+        query = parse_qs(urlparse(self.path).query)
+        try:
+            slot = int(query.get("slot", ["0"])[0])
+        except ValueError:
+            self._send_json(400, {"error": "slot must be an integer"})
+            return
+        if slot == 0:
+            slot = SAVE_SLOT
+        if not (1 <= slot <= 10):
+            self._send_json(400, {"error": "slot must be 0–10"})
+            return
+
+        # Block while a save is being written so the caller never receives a
+        # half-written or stale file right after triggering a save.
+        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+
+        state_path = _newest_state_for_slot(slot)
+        if state_path is None:
+            self._send_json(404, {"error": "no state file for slot", "slot": slot})
+            return
+        try:
+            content = state_path.read_bytes()
+        except OSError as exc:
+            self._send_json(500, {"error": f"could not read state file: {exc}"})
+            return
+        if len(content) > STATE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "state file exceeds size limit"})
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("X-State-Filename", state_path.name)
+        self.end_headers()
+        self.wfile.write(content)
+        log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
+
+    def do_PUT(self):
+        if not self._check_secret():
+            self._send_json(403, {"error": "forbidden"})
+            return
+        parsed = urlparse(self.path)
+        if parsed.path != "/state-file":
+            self._send_json(404, {"error": "not found"})
+            return
+
+        # Basename only — the filename came from a previous GET and is written
+        # back verbatim so PCSX2 recognises the slot; path parts are rejected.
+        raw_name = parse_qs(parsed.query).get("filename", [""])[0]
+        filename = Path(raw_name).name
+        if not filename or filename.startswith(".") or not filename.endswith(".p2s"):
+            self._send_json(400, {"error": "filename must be a .p2s basename"})
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or invalid Content-Length"})
+            return
+        if length > STATE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "state file exceeds size limit"})
+            return
+        content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
+
+        tmp = SSTATE_DIR / f".{filename}.tmp"
+        try:
+            SSTATE_DIR.mkdir(parents=True, exist_ok=True)
+            tmp.write_bytes(content)
+            # PCSX2 runs as abc and must be able to overwrite the slot later.
+            os.chown(tmp, _LOG_UID, _LOG_GID)
+            os.replace(tmp, SSTATE_DIR / filename)
+        except OSError as exc:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            self._send_json(500, {"error": f"could not write state file: {exc}"})
+            return
+        log.info("state-file: stored %s (%d bytes)", filename, length)
+        self._send_json(200, {"status": "ok", "filename": filename})
+
     def do_GET(self):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
@@ -956,6 +1079,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             # /health stays open for container healthchecks; all other GETs
             # require the shared secret, matching POST/DELETE.
             self._send_json(403, {"error": "forbidden"})
+        elif urlparse(self.path).path == "/state-file":
+            self._get_state_file()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -452,7 +452,7 @@ def _wait_for_no_pcsx2(timeout: float = 3.0) -> bool:
     return False
 
 
-def _launch_pcsx2(rom_path):
+def _launch_pcsx2(rom_path, release_claim=False):
     try:
         _kill_pcsx2()
         _drain_gamepad_sockets()
@@ -469,10 +469,12 @@ def _launch_pcsx2(rom_path):
             )
         _launch_pcsx2_internal(rom_path)
     finally:
-        # Release the /launch claim. Harmless no-op for dashboard relaunches
-        # that never set it.
-        with _session_lock:
-            _session["launch_in_progress"] = False
+        # Only the caller that claimed launch_in_progress (POST /launch) may
+        # release it — a dashboard relaunch clearing it unconditionally would
+        # wipe a concurrent /launch's claim and reopen the TOCTOU.
+        if release_claim:
+            with _session_lock:
+                _session["launch_in_progress"] = False
 
 
 def _sstate_snapshot() -> dict:
@@ -1051,7 +1053,9 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 return
             _session["launch_in_progress"] = True
 
-        Thread(target=_launch_pcsx2, args=(str(rom_path),), daemon=True).start()
+        Thread(
+            target=_launch_pcsx2, args=(str(rom_path), True), daemon=True
+        ).start()
         self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
 
     def do_DELETE(self):

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import socket as _socket
+import struct
 import subprocess
 import sys
 import time
@@ -109,8 +110,7 @@ ENV = {
 
 INI_PATH = Path("/config/.config/PCSX2/inis/PCSX2.ini")
 
-# Env var name kept as PINE_WAIT for backwards compatibility with existing
-# deployments; it now bounds the xdotool save-state write poll.
+# Bounds the save-state write-confirmation poll (PINE and xdotool paths).
 PINE_WAIT    = float(os.environ.get("PINE_WAIT",   "20.0"))   # max seconds to poll for write completion
 SAVE_SLOT    = int(os.environ.get("SAVE_SLOT", "10"))
 SSTATE_DIR   = Path(os.environ.get("SSTATE_DIR", "/config/.config/PCSX2/sstates"))
@@ -458,7 +458,14 @@ def _launch_pcsx2(rom_path, release_claim=False):
         _drain_gamepad_sockets()
         _patch_ini()
         if not _wait_for_no_pcsx2():
-            log.warning("pcsx2-qt still running after kill+drain; relaunching anyway")
+            # _kill_pcsx2 already reaped the managed process group, so any
+            # survivor is an unmanaged stray. Strays sit on top of the new
+            # game window, steal xdotool targeting, and unlink the live
+            # instance's PINE socket when they finally exit — reap them.
+            log.warning("Stray pcsx2-qt still running after kill+drain — sending SIGKILL")
+            subprocess.run(["pkill", "-9", "-x", "pcsx2-qt"], capture_output=True)
+            if not _wait_for_no_pcsx2():
+                log.error("Stray pcsx2-qt survived SIGKILL; new instance may misbehave")
         with _session_lock:
             _session["rom_path"] = rom_path
             _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
@@ -544,6 +551,98 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
         time.sleep(POLL_SECS)
 
     return False
+
+
+# ── PINE IPC ──────────────────────────────────────────────────────────────────
+# PCSX2's native IPC protocol. _patch_ini enables it (EnablePINE = true) and
+# pcsx2-qt listens on a unix socket in XDG_RUNTIME_DIR. Used as the primary
+# save/load-state channel: xdotool F-key delivery is unreliable against
+# pcsx2-qt (both XSendEvent and XTEST presses are dropped), so keypresses are
+# only a fallback for the window between launch and PINE socket creation.
+
+PINE_SOCKET = Path(XDG_RUNTIME_DIR) / "pcsx2.sock"
+
+_PINE_MSG_SAVE_STATE = 0x09
+_PINE_MSG_LOAD_STATE = 0x0A
+
+
+def _pine_recv_exact(sock: _socket.socket, n: int) -> bytes | None:
+    """Read exactly n bytes, or None if the peer closes early."""
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def _pine_request(opcode: int, payload: bytes = b"", timeout: float = 5.0) -> bytes | None:
+    """Send one PINE request and return the reply payload, or None on failure.
+
+    Wire format (little-endian): request is u32 total packet size (including
+    the size field itself), u8 opcode, then payload. Reply is u32 size,
+    u8 result code (0 = OK), then reply payload.
+    """
+    packet = struct.pack("<IB", 5 + len(payload), opcode) + payload
+    try:
+        with _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(str(PINE_SOCKET))
+            sock.sendall(packet)
+            header = _pine_recv_exact(sock, 5)
+            if header is None:
+                log.warning("PINE: connection closed before reply header (opcode 0x%02X)", opcode)
+                return None
+            size, result = struct.unpack("<IB", header)
+            body = b""
+            if size > 5:
+                body = _pine_recv_exact(sock, size - 5) or b""
+            if result != 0:
+                log.warning("PINE: opcode 0x%02X rejected (result %d)", opcode, result)
+                return None
+            return body
+    except OSError as exc:
+        # socket.timeout is an OSError subclass, so this covers timeouts too.
+        log.warning("PINE: request failed on %s (opcode 0x%02X): %s", PINE_SOCKET, opcode, exc)
+        return None
+
+
+def _pine_save_state(slot: int) -> bool | None:
+    """Save state to `slot` via PINE.
+
+    Returns True on a confirmed state file write, False if PCSX2 accepted the
+    command but no write appeared within PINE_WAIT, and None if the PINE
+    request itself failed (caller should fall back to xdotool).
+    """
+    before = _sstate_snapshot()
+    if _pine_request(_PINE_MSG_SAVE_STATE, bytes([slot])) is None:
+        return None
+    # PCSX2 queues the save onto the VM thread and replies immediately, so
+    # confirm the actual write the same way the xdotool path does.
+    log.info("PINE: save state accepted (slot %d) — waiting for write (max %.1fs)", slot, PINE_WAIT)
+    if _wait_for_sstate_write(before, time.monotonic() + PINE_WAIT):
+        return True
+    log.warning("PINE: save accepted but no state file write within %.1fs (slot %d)", PINE_WAIT, slot)
+    return False
+
+
+def _save_state(slot: int) -> bool:
+    """Save state via PINE, falling back to xdotool keypresses."""
+    result = _pine_save_state(slot)
+    if result is not None:
+        return result
+    log.warning("PINE unavailable — falling back to xdotool F-key delivery")
+    return _xdotool_save_state(slot)
+
+
+def _load_state(slot: int) -> bool:
+    """Load state via PINE, falling back to xdotool keypresses."""
+    if _pine_request(_PINE_MSG_LOAD_STATE, bytes([slot])) is not None:
+        log.info("PINE: load state accepted (slot %d)", slot)
+        return True
+    log.warning("PINE unavailable — falling back to xdotool F-key delivery")
+    return _xdotool_load_state(slot)
 
 
 _XDOTOOL_ENV = {
@@ -749,7 +848,7 @@ def _xdotool_load_state(slot: int) -> bool:
 
 def _save_and_exit(slot: int) -> bool:
     """Save emulator state then kill PCSX2. Returns True if save succeeded."""
-    ok = _xdotool_save_state(slot)
+    ok = _save_state(slot)
     _kill_pcsx2()
     return ok
 
@@ -985,7 +1084,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 return
             def _bg_save(s):
                 try:
-                    ok = _xdotool_save_state(s)
+                    ok = _save_state(s)
                 finally:
                     with _session_lock:
                         _session["save_in_progress"] = False
@@ -1005,17 +1104,17 @@ class BrokerHandler(BaseHTTPRequestHandler):
             if not isinstance(slot, int) or not (1 <= slot <= 10):
                 self._send_json(400, {"error": "slot must be 1–10"})
                 return
-            ok = _xdotool_load_state(slot)
+            ok = _load_state(slot)
             if ok:
                 self._send_json(200, {"status": "ok", "loaded": True, "slot": slot})
             else:
-                # 503: PCSX2 is the upstream and we couldn't reach its window
-                # (xdotool find/dispatch failed). The broker itself is healthy.
+                # 503: PCSX2 is the upstream and we couldn't reach it over
+                # PINE or xdotool. The broker itself is healthy.
                 self._send_json(503, {
                     "status": "error",
                     "loaded": False,
                     "slot": slot,
-                    "error": "could not deliver F3 to PCSX2 window (window not found or xdotool failure)",
+                    "error": "could not deliver load-state to PCSX2 (PINE and xdotool both failed)",
                 })
             return
 
@@ -1081,7 +1180,7 @@ def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
     Thread(target=server.shutdown, daemon=True).start()
 
     # Wait briefly for any in-flight save to finish. The /save-and-exit handler
-    # holds save_in_progress for the duration of the F1+poll cycle.
+    # holds save_in_progress for the duration of the save request + write poll.
     deadline = time.monotonic() + max(PINE_WAIT, 5.0)
     while time.monotonic() < deadline:
         with _session_lock:

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """broker.py — launch PCSX2 on demand and expose a small HTTP API."""
 
+import calendar
 import glob
 import hmac
 import io
@@ -166,7 +167,12 @@ _session: dict = {
     "started_at":       None,
     "is_managed":       False,
     "save_in_progress": False,
-    "launch_in_progress": False,  # guards against concurrent /launch requests
+    "launch_in_progress": False,  # claim shared by every kill+relaunch path
+    "launch_seq":       0,      # bumped per launch; stale deferred loads abort
+    "card_op_in_progress": False,  # a /memory-card replace is mid-flight
+    # Set when the crash-loop limiter gives up. /status exposes it so a pooled
+    # fleet can tell "idle, waiting for a user" from "broker surrendered".
+    "relaunch_abandoned": False,
     "current_slot":     1,      # tracks PCSX2's active save state slot (resets to 1 on each launch)
     # Wall-clock stamp of the last GAME launch (not dashboard relaunches).
     # GET /save-file only ships files modified at or after this point; it
@@ -355,7 +361,10 @@ def _launch_pcsx2_internal(rom_path):
             cmd,
             stdout=log_fh if log_fh else subprocess.DEVNULL,
             stderr=subprocess.STDOUT if log_fh else subprocess.DEVNULL,
-            preexec_fn=os.setpgrp,  # own process group so killpg is clean
+            # New session ⇒ own process group, so killpg is clean. Unlike
+            # preexec_fn (unsafe with threads — can deadlock between fork and
+            # exec in this ThreadingHTTPServer process), this is thread-safe.
+            start_new_session=True,
         )
     except OSError as exc:
         log.error("Failed to launch PCSX2: %s", exc)
@@ -374,6 +383,8 @@ def _launch_pcsx2_internal(rom_path):
     with _session_lock:
         _session["process"] = proc
         _session["is_managed"] = True
+        # An instance is up again — whatever the limiter concluded is stale.
+        _session["relaunch_abandoned"] = False
         # PCSX2's persisted slot from PCSX2.ini, or BROKER_INITIAL_SLOT.
         # We can't query PCSX2 for its live slot, so this is a best-effort seed
         # that tracks the same value PCSX2 itself loads on startup.
@@ -382,15 +393,43 @@ def _launch_pcsx2_internal(rom_path):
     Thread(target=_monitor_process, args=(proc, time.monotonic()), daemon=True).start()
 
 
+# Consecutive sub-5s exits before the monitor stops relaunching. A pcsx2-qt
+# that dies instantly every time (missing lib, dead display) must not respawn
+# forever; an explicit POST /launch resets the counter so recovery is manual.
+_CRASH_LOOP_LIMIT = 3
+_rapid_exits = 0  # guarded by _session_lock
+
+
 def _monitor_process(proc, start_time):
     """On unexpected exit, relaunch into dashboard mode if the session is still managed."""
+    global _rapid_exits
     proc.wait()
     duration = time.monotonic() - start_time
 
+    rapid = 0
     with _session_lock:
         should_relaunch = _session["is_managed"] and _session["process"] is proc
+        # Only unexpected exits count toward the crash-loop limit — a
+        # deliberate kill (/save-and-exit, DELETE /launch) cleared is_managed
+        # and must not push the counter toward a false trip.
+        if should_relaunch:
+            if duration < 5:
+                _rapid_exits += 1
+            else:
+                _rapid_exits = 0
+            rapid = _rapid_exits
 
     if not should_relaunch:
+        return
+
+    if rapid >= _CRASH_LOOP_LIMIT:
+        log.error(
+            "PCSX2 exited within 5s %d times in a row — giving up on relaunch. "
+            "Fix the underlying failure, then POST /launch to recover.",
+            rapid,
+        )
+        with _session_lock:
+            _session["relaunch_abandoned"] = True
         return
 
     # Back off if the process died almost immediately to avoid a tight crash loop.
@@ -398,17 +437,30 @@ def _monitor_process(proc, start_time):
     log.info("PCSX2 exited after %.1fs — relaunching dashboard in %ds", duration, wait_time)
     time.sleep(wait_time)
 
-    with _session_lock:
-        # Re-check: _kill_pcsx2 may have fired during the sleep above.
-        if not _session["is_managed"]:
-            return
-        _session["rom_path"] = None
-        _session["rom_name"] = "Dashboard"
-        # Dashboard is an idle state, not a session; clearing started_at lets
-        # /status reliably distinguish "playing" from "not playing".
-        _session["started_at"] = None
-
-    _launch_pcsx2_internal(None)
+    # The crash relaunch is a lifecycle sequence like any other: it must hold
+    # the launch claim, or a concurrent /launch interleaves with it and the
+    # monitor stomps the new game's session state with Dashboard.
+    if not _claim_launch():
+        log.info("Crash relaunch skipped — a launch is already in progress")
+        return
+    try:
+        with _session_lock:
+            # Re-check under the claim: _kill_pcsx2 ended the session, or a
+            # /launch that completed before we claimed installed a new process
+            # (in which case `process` is no longer OUR dead proc).
+            if not _session["is_managed"] or _session["process"] is not proc:
+                return
+            # Supersede any deferred slot load still pending for the dead launch.
+            _session["launch_seq"] += 1
+            _session["rom_path"] = None
+            _session["rom_name"] = "Dashboard"
+            # Dashboard is an idle state, not a session; clearing started_at lets
+            # /status reliably distinguish "playing" from "not playing".
+            _session["started_at"] = None
+        _launch_pcsx2_internal(None)
+    finally:
+        with _session_lock:
+            _session["launch_in_progress"] = False
 
 
 def _drain_gamepad_sockets():
@@ -469,7 +521,18 @@ def _wait_for_no_pcsx2(timeout: float = 3.0) -> bool:
     return False
 
 
-def _launch_pcsx2(rom_path, release_claim=False):
+def _claim_launch() -> bool:
+    """Atomically claim launch_in_progress. Every kill+relaunch path must hold
+    this claim so two lifecycle sequences can never interleave."""
+    with _session_lock:
+        if _session["launch_in_progress"]:
+            return False
+        _session["launch_in_progress"] = True
+        return True
+
+
+def _launch_pcsx2(rom_path, release_claim=False, load_slot=None):
+    global _rapid_exits
     try:
         _kill_pcsx2()
         _drain_gamepad_sockets()
@@ -484,6 +547,11 @@ def _launch_pcsx2(rom_path, release_claim=False):
             if not _wait_for_no_pcsx2():
                 log.error("Stray pcsx2-qt survived SIGKILL; new instance may misbehave")
         with _session_lock:
+            # An explicit launch is a fresh start: clear the crash-loop counter
+            # and supersede any pending deferred slot load from a prior launch.
+            _rapid_exits = 0
+            _session["launch_seq"] += 1
+            seq = _session["launch_seq"]
             _session["rom_path"] = rom_path
             _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
             # Only stamp a session start when an actual ROM is being played. The
@@ -496,13 +564,66 @@ def _launch_pcsx2(rom_path, release_claim=False):
             if rom_path:
                 _session["save_baseline"] = time.time()
         _launch_pcsx2_internal(rom_path)
+        if load_slot is not None:
+            # Spawned here (not by the HTTP handler) so the deferred loader
+            # carries this launch's seq and aborts if a later launch lands.
+            # Skipped when Popen failed — no point polling PINE for
+            # RESUME_LOAD_WAIT against a VM that never started.
+            with _session_lock:
+                launched = _session["process"] is not None
+            if launched:
+                Thread(
+                    target=_deferred_load_state, args=(load_slot, seq), daemon=True
+                ).start()
+            else:
+                log.warning("resume: launch failed — slot %d load not scheduled", load_slot)
     finally:
-        # Only the caller that claimed launch_in_progress (POST /launch) may
-        # release it — a dashboard relaunch clearing it unconditionally would
-        # wipe a concurrent /launch's claim and reopen the TOCTOU.
+        # Only the caller that claimed launch_in_progress may release it —
+        # clearing it unconditionally would wipe a concurrent claim and
+        # reopen the TOCTOU.
         if release_claim:
             with _session_lock:
                 _session["launch_in_progress"] = False
+
+
+def _claim_card_op() -> bool:
+    """Claim the memory-card slot for a whole-card replace.
+
+    Deliberately NOT launch_in_progress: a card op launches nothing, so
+    borrowing the launch claim made the monitor's crash relaunch skip and
+    never retry, leaving no emulator running at all. This flag blocks GAME
+    launches (which mount the card) while letting the gameless dashboard
+    recover — the dashboard never opens a memory card, and the replace is an
+    atomic staging swap, so a relaunch mid-hydrate sees either the old card
+    or the new one, never a partial.
+
+    Refuses when a game is running or a launch is in flight; those states end
+    with a mounted card.
+    """
+    with _session_lock:
+        if (
+            _session["rom_path"] is not None
+            or _session["launch_in_progress"]
+            or _session["card_op_in_progress"]
+        ):
+            return False
+        _session["card_op_in_progress"] = True
+        return True
+
+
+def _release_card_op() -> None:
+    with _session_lock:
+        _session["card_op_in_progress"] = False
+
+
+def _relaunch_dashboard():
+    """Dashboard relaunch that respects the launch claim. If a /launch is
+    already in flight, skip: that launch's kill+start sequence supersedes
+    the dashboard anyway, and interleaving the two corrupts both."""
+    if not _claim_launch():
+        log.info("Dashboard relaunch skipped — a launch is already in progress")
+        return
+    _launch_pcsx2(None, release_claim=True)
 
 
 def _sstate_snapshot() -> dict:
@@ -521,10 +642,17 @@ def _sstate_snapshot() -> dict:
     return snap
 
 
-def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
+def _matches_slot(p: Path, slot: int) -> bool:
+    """True when a state file's name targets `slot` (padded or bare suffix)."""
+    return p.name.endswith(f".{slot:02d}.p2s") or p.name.endswith(f".{slot}.p2s")
+
+
+def _wait_for_sstate_write(before: dict, deadline: float, slot: int | None = None) -> bool:
     """Poll SSTATE_DIR until a save state write completes or deadline is reached.
 
-    Detects both new files and overwrites of existing ones (by mtime change).
+    When `slot` is given, only files named for that slot count — otherwise an
+    unrelated .p2s write (autosave, user F1) would confirm a save that never
+    happened. Detects both new files and overwrites of existing ones (by mtime change).
     Once a target file is found, waits for its size to be stable for 0.5 s
     before returning — handles both direct writes and atomic rename patterns.
 
@@ -542,6 +670,8 @@ def _wait_for_sstate_write(before: dict, deadline: float) -> bool:
 
         if target is None:
             for p, (size, mtime) in after.items():
+                if slot is not None and not _matches_slot(p, slot):
+                    continue
                 prev = before.get(p)
                 if prev is None or prev[1] != mtime:
                     target = p
@@ -584,13 +714,16 @@ STATE_FILE_MAX_BYTES = 256 * 1024 * 1024
 STATE_GET_WAIT = float(os.environ.get("STATE_GET_WAIT", "30.0"))
 
 
-def _wait_for_save_idle(deadline: float) -> None:
-    """Block until no save is in flight, or the deadline passes."""
+def _wait_for_save_idle(deadline: float) -> bool:
+    """Block until no save is in flight. Returns False when the deadline
+    passes with a save still running — callers must refuse to serve state
+    files in that case, not ship a half-written one."""
     while time.monotonic() < deadline:
         with _session_lock:
             if not _session["save_in_progress"]:
-                return
+                return True
         time.sleep(0.2)
+    return False
 
 
 def _newest_state_for_slot(slot: int) -> Path | None:
@@ -679,7 +812,7 @@ def _pine_save_state(slot: int) -> bool | None:
     # PCSX2 queues the save onto the VM thread and replies immediately, so
     # confirm the actual write the same way the xdotool path does.
     log.info("PINE: save state accepted (slot %d) — waiting for write (max %.1fs)", slot, PINE_WAIT)
-    if _wait_for_sstate_write(before, time.monotonic() + PINE_WAIT):
+    if _wait_for_sstate_write(before, time.monotonic() + PINE_WAIT, slot):
         return True
     log.warning("PINE: save accepted but no state file write within %.1fs (slot %d)", PINE_WAIT, slot)
     return False
@@ -711,20 +844,32 @@ def _pine_emu_status() -> int | None:
     return struct.unpack("<I", body[:4])[0]
 
 
-def _deferred_load_state(slot: int) -> None:
+def _deferred_load_state(slot: int, seq: int) -> None:
     """Resume-from-state: load `slot` once the freshly launched game's VM is up.
 
     Waits for the launch to finish swapping instances before trusting the
     status probe — probing earlier could see a still-running previous game
     and load the slot into the wrong VM. After the swap, only the new game
     VM reports running (a gameless relaunch reports shutdown).
+
+    `seq` is the launch_seq of the launch this load belongs to; if any other
+    launch lands during the (up to 90s) wait, the load is abandoned rather
+    than delivered into the wrong game's VM.
     """
     deadline = time.monotonic() + RESUME_LOAD_WAIT
     while time.monotonic() < deadline:
         with _session_lock:
             launching = _session["launch_in_progress"]
+            superseded = _session["launch_seq"] != seq
+        if superseded:
+            log.info("resume: launch superseded — slot %d load abandoned", slot)
+            return
         if not launching and _pine_emu_status() == 0:
             time.sleep(RESUME_LOAD_SETTLE)
+            with _session_lock:
+                if _session["launch_seq"] != seq:
+                    log.info("resume: launch superseded — slot %d load abandoned", slot)
+                    return
             ok = _load_state(slot)
             log.info("resume: deferred load of slot %d %s", slot, "delivered" if ok else "failed")
             return
@@ -828,7 +973,8 @@ def _xdotool_cycle_to_slot(wid: str, slot: int) -> bool:
     for _ in range(cycles):
         try:
             subprocess.run(
-                xdo_cmd + ["key", "--window", wid, key], timeout=5, check=True
+                xdo_cmd + ["key", "--window", wid, key],
+                capture_output=True, text=True, timeout=5, check=True,
             )
         except subprocess.CalledProcessError as exc:
             log.error("xdotool: slot cycle keypress failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
@@ -882,7 +1028,10 @@ def _xdotool_save_state(slot: int) -> bool:
         + ["xdotool"]
     )
     try:
-        subprocess.run(xdo_cmd + ["key", "--window", wid, "F1"], timeout=5, check=True)
+        subprocess.run(
+            xdo_cmd + ["key", "--window", wid, "F1"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
     except subprocess.CalledProcessError as exc:
         log.error("xdotool: F1 send failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
         return False
@@ -898,7 +1047,7 @@ def _xdotool_save_state(slot: int) -> bool:
         wid, slot, PINE_WAIT,
     )
     deadline = time.monotonic() + PINE_WAIT
-    if not _wait_for_sstate_write(before, deadline):
+    if not _wait_for_sstate_write(before, deadline, slot):
         # Same contract as _pine_save_state: an unconfirmed write is a failed
         # save, so callers never report saved=true for a state that may not exist.
         log.warning("xdotool: save state write not confirmed within %.1fs (F1 was sent)", PINE_WAIT)
@@ -921,7 +1070,10 @@ def _xdotool_load_state(slot: int) -> bool:
         + ["xdotool"]
     )
     try:
-        subprocess.run(xdo_cmd + ["key", "--window", wid, "F3"], timeout=5, check=True)
+        subprocess.run(
+            xdo_cmd + ["key", "--window", wid, "F3"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
     except subprocess.CalledProcessError as exc:
         log.error("xdotool: F3 send failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
         return False
@@ -1015,6 +1167,15 @@ _SAVE_DATA_ROOTS = (
 # Archive members must live under one of these root-relative subtrees; PUT
 # rejects anything else so a crafted zip cannot reach configs or savestates.
 SAVE_SYNC_SUBTREES = ("memcards",)
+# A PS2 memory card is 8 MB and a folder card holds one game's saves per
+# subfolder, so 256 MB is far above anything real. It is a hard ceiling, not a
+# tunable: exceeding it fails the sync outright (GET 413 / PUT 413), it is NOT
+# read from the environment, and both the whole archive and the extracted size
+# are held in memory. If a card ever legitimately grows past this — a card pool
+# far larger than expected, or a future non-memcard subtree added to
+# SAVE_SYNC_SUBTREES — raising the number alone is not enough: the transfer has
+# to move to streaming/chunked I/O first, or the broker will OOM before it hits
+# the limit. Same reasoning applies to STATE_FILE_MAX_BYTES above.
 SAVE_FILE_MAX_BYTES = 256 * 1024 * 1024
 # Zip stores mtimes at 2 s DOS resolution; the slack keeps the newer-file
 # guard from skipping files over rounding alone.
@@ -1122,9 +1283,12 @@ def _build_save_archive(baseline: float) -> tuple[bytes | None, int] | None | st
                 skipped += 1
                 continue
             data, mtime = result
+            # UTC, matched by calendar.timegm on extract — a TZ difference
+            # between the GET and PUT containers must not shift mtimes and
+            # silently break the newer-file guard.
             info = zipfile.ZipInfo(
                 p.relative_to(root).as_posix(),
-                date_time=time.localtime(mtime)[:6],
+                date_time=time.gmtime(mtime)[:6],
             )
             zf.writestr(info, data, zipfile.ZIP_DEFLATED)
             wrote += 1
@@ -1149,12 +1313,15 @@ def _mkdirs_owned(path: Path) -> None:
             pass
 
 
-def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
+def _extract_save_archive(content: bytes) -> tuple[int, int, int] | str:
     """Restore a pulled save archive into the data dir.
 
-    Returns (written, skipped) on success, or an error string for a bad
-    archive. Existing files newer than their archive member are skipped so a
-    restore can never roll back saves made since the archive was taken."""
+    Returns (written, skipped, failed), or an error string for a bad archive.
+    Existing files newer than their archive member are skipped so a restore
+    can never roll back saves made since the archive was taken. A per-file
+    write failure doesn't abort the restore — remaining members still land,
+    the failure is counted, and the handler reports it; the mtime guard
+    makes a retry of the same archive idempotent."""
     root = _save_data_root() or _SAVE_DATA_ROOTS[0]
     try:
         zf = zipfile.ZipFile(io.BytesIO(content))
@@ -1173,10 +1340,10 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
             ):
                 return f"archive member outside save subtrees: {info.filename}"
 
-        written = skipped = 0
+        written = skipped = failed = 0
         for info in infos:
             target = root / PurePosixPath(info.filename)
-            mtime = time.mktime(info.date_time + (0, 0, -1))
+            mtime = calendar.timegm(info.date_time)
             try:
                 if (
                     target.exists()
@@ -1191,9 +1358,11 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
                 os.replace(tmp, target)
                 os.utime(target, (mtime, mtime))
             except OSError as exc:
-                return f"could not write {info.filename}: {exc}"
+                log.warning("save-file: could not restore %s — %s", info.filename, exc)
+                failed += 1
+                continue
             written += 1
-    return (written, skipped)
+    return (written, skipped, failed)
 
 
 # ── Whole memory-card sync (per-user card model) ──────────────────────────────
@@ -1202,6 +1371,12 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
 # host-independent image, so a user's card can be hydrated onto any pooled
 # container. GET evacuates the whole card; PUT wipes Slot 1 and lays the card
 # back down. Only Slot 1 is ever touched — Slot 2 is never synced.
+
+
+# Serializes whole-card operations: os.getpid() is constant in this process,
+# so two concurrent PUTs would otherwise share staging/backup paths and
+# rmtree each other mid-write.
+_memcard_lock = Lock()
 
 
 def _memcards_dir() -> Path:
@@ -1410,19 +1585,23 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         # Block while a save is being written so the caller never receives a
         # half-written or stale file right after triggering a save.
-        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+        if not _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT):
+            self._send_json(503, {"error": "save still in progress; retry shortly"})
+            return
 
         state_path = _newest_state_for_slot(slot)
         if state_path is None:
             self._send_json(404, {"error": "no state file for slot", "slot": slot})
             return
         try:
+            # Size-check via stat before reading — never hold an oversized
+            # file in memory just to refuse it.
+            if state_path.stat().st_size > STATE_FILE_MAX_BYTES:
+                self._send_json(413, {"error": "state file exceeds size limit"})
+                return
             content = state_path.read_bytes()
         except OSError as exc:
             self._send_json(500, {"error": f"could not read state file: {exc}"})
-            return
-        if len(content) > STATE_FILE_MAX_BYTES:
-            self._send_json(413, {"error": "state file exceeds size limit"})
             return
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")
@@ -1486,16 +1665,37 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(413, {"error": "archive too large"})
             return
         content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
         result = _extract_save_archive(content)
         if isinstance(result, str):
             self._send_json(400, {"error": result})
             return
-        written, skipped = result
+        written, skipped, failed = result
+        if failed:
+            log.warning(
+                "save-file: restore incomplete — %d written, %d skipped, %d failed",
+                written, skipped, failed,
+            )
+            self._send_json(500, {
+                "error": "some archive members could not be written",
+                "written": written, "skipped": skipped, "failed": failed,
+            })
+            return
         log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
         self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
 
     def _get_memory_card(self):
-        result = _build_memory_card_archive()
+        # Same non-blocking policy as PUT: contention means a card operation
+        # is mid-flight, and the caller should retry rather than queue up.
+        if not _memcard_lock.acquire(blocking=False):
+            self._send_json(409, {"error": "memory card operation already in progress"})
+            return
+        try:
+            result = _build_memory_card_archive()
+        finally:
+            _memcard_lock.release()
         if isinstance(result, str):
             # e.g. slot 1 is a File card, not a Folder card.
             self._send_json(409, {"error": result})
@@ -1519,6 +1719,17 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("memory-card: served slot-1 card (%d bytes)", len(result))
 
     def _put_memory_card(self):
+        # PCSX2 holds the folder card open while a game VM is up; replacing
+        # it underneath the emulator corrupts the card. Hydration belongs
+        # before launch (or after exit), never mid-game. This early check is
+        # just a fast-fail before the (large) body read; the authoritative
+        # check runs under the launch claim below.
+        with _session_lock:
+            if _session["rom_path"] is not None or _session["launch_in_progress"]:
+                self._send_json(
+                    409, {"error": "cannot replace memory card while a game is running"}
+                )
+                return
         try:
             length = int(self.headers.get("Content-Length", 0))
         except ValueError:
@@ -1533,7 +1744,24 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if len(content) != length:
             self._send_json(400, {"error": "truncated request body"})
             return
-        result = _replace_memory_card(content)
+        # Claim for the whole replace. Re-checks "no game running" atomically,
+        # closing the TOCTOU against a /launch that lands during the body read
+        # above — POST /launch refuses while this claim is held.
+        if not _claim_card_op():
+            self._send_json(
+                409, {"error": "cannot replace memory card while a game is running or launching"}
+            )
+            return
+        try:
+            if not _memcard_lock.acquire(blocking=False):
+                self._send_json(409, {"error": "memory card operation already in progress"})
+                return
+            try:
+                result = _replace_memory_card(content)
+            finally:
+                _memcard_lock.release()
+        finally:
+            _release_card_op()
         if isinstance(result, str):
             self._send_json(400, {"error": result})
             return
@@ -1617,11 +1845,16 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     and _session["process"].poll() is None
                 )
                 snap = dict(_session) if active else {}
+                abandoned = _session["relaunch_abandoned"]
             self._send_json(200, {
                 "active":     active,
                 "rom_path":   snap.get("rom_path")   if active else None,
                 "rom_name":   snap.get("rom_name")   if active else None,
                 "started_at": snap.get("started_at") if active else None,
+                # True once the crash-loop limiter gave up: nothing is running
+                # and nothing will restart it without an explicit POST /launch.
+                # Distinguishes a dead container from an idle dashboard.
+                "relaunch_abandoned": abandoned,
             })
         else:
             self._send_json(404, {"error": "not found"})
@@ -1671,7 +1904,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     log.warning("streaming: save state failed (slot %d) — relaunching dashboard anyway", slot)
                 self._send_json(200, {"status": "ok", "saved": ok, "slot": slot})
                 # Relaunch to dashboard regardless of save result — PCSX2 is already dead.
-                Thread(target=_launch_pcsx2, args=(None,), daemon=True).start()
+                Thread(target=_relaunch_dashboard, daemon=True).start()
             else:
                 # Clear visible session state synchronously so that callers
                 # polling /status immediately after this response observe
@@ -1691,7 +1924,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     if not ok:
                         log.warning("streaming: save state failed (slot %d) — relaunching dashboard anyway", s)
                     # Relaunch to dashboard regardless of save result — PCSX2 is already dead.
-                    _launch_pcsx2(None)
+                    _relaunch_dashboard()
                 Thread(target=_bg, args=(slot,), daemon=True).start()
                 self._send_json(200, {"status": "queued", "slot": slot})
             return
@@ -1829,15 +2062,16 @@ class BrokerHandler(BaseHTTPRequestHandler):
             if _session["launch_in_progress"]:
                 self._send_json(409, {"error": "launch already in progress"})
                 return
+            # A game launch mounts the memory card; starting one mid-hydrate
+            # would race the card swap.
+            if _session["card_op_in_progress"]:
+                self._send_json(409, {"error": "memory card operation in progress"})
+                return
             _session["launch_in_progress"] = True
 
         Thread(
-            target=_launch_pcsx2, args=(str(rom_path), True), daemon=True
+            target=_launch_pcsx2, args=(str(rom_path), True, load_slot), daemon=True
         ).start()
-        if load_slot is not None:
-            Thread(
-                target=_deferred_load_state, args=(load_slot,), daemon=True
-            ).start()
         self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
 
     def do_DELETE(self):
@@ -1848,7 +2082,12 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "not found"})
             return
 
-        Thread(target=_launch_pcsx2, args=(None,), daemon=True).start()
+        # Same claim as POST /launch — a soft reset interleaved with a live
+        # launch would run two kill+start sequences against one session.
+        if not _claim_launch():
+            self._send_json(409, {"error": "launch already in progress"})
+            return
+        Thread(target=_launch_pcsx2, args=(None, True), daemon=True).start()
         log.info("Soft reset: returning to dashboard")
         self._send_json(200, {"status": "resetting"})
 
@@ -1864,14 +2103,15 @@ def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
 
     # Wait briefly for any in-flight save to finish. The /save-and-exit handler
     # holds save_in_progress for the duration of the save request + write poll.
-    deadline = time.monotonic() + max(PINE_WAIT, 5.0)
+    save_wait = max(PINE_WAIT, 5.0)
+    deadline = time.monotonic() + save_wait
     while time.monotonic() < deadline:
         with _session_lock:
             if not _session["save_in_progress"]:
                 break
         time.sleep(0.2)
     else:
-        log.warning("Shutdown: in-flight save did not complete within %.1fs — killing PCSX2 anyway", PINE_WAIT)
+        log.warning("Shutdown: in-flight save did not complete within %.1fs — killing PCSX2 anyway", save_wait)
 
     _kill_pcsx2()
     log.info("Shutdown complete")

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -22,29 +22,87 @@ PORT     = int(os.environ.get("BROKER_PORT", "8000"))
 SECRET   = os.environ.get("BROKER_SECRET", "")
 ROM_ROOT = Path(os.environ.get("ROM_ROOT", "/romm/library")).resolve()
 
-def _detect_display() -> str:
-    """Return the actual X display by scanning /tmp/.X11-unix/. The DISPLAY env
-    var set by the linuxserver image is just a default — Xvfb may land elsewhere
-    if stale lock files exist (e.g. across container restarts on Podman)."""
+XDG_RUNTIME_DIR = "/config/.XDG"
+
+
+def _live_x_sockets() -> list[Path]:
+    """Return X11 sockets that have a listening peer, newest first.
+    A bare /tmp/.X11-unix/X<N> file with no Xvfb behind it is a stale lock
+    that must be skipped or the broker will hand pcsx2-qt a dead display."""
+    candidates: list[tuple[float, Path]] = []
     try:
-        for sock in sorted(os.listdir("/tmp/.X11-unix")):
-            if sock.startswith("X") and sock[1:].isdigit():
-                return f":{sock[1:]}"
+        for entry in os.listdir("/tmp/.X11-unix"):
+            if not (entry.startswith("X") and entry[1:].isdigit()):
+                continue
+            p = Path("/tmp/.X11-unix") / entry
+            try:
+                st = p.stat()
+                with _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM) as s:
+                    s.settimeout(0.2)
+                    s.connect(str(p))
+                candidates.append((st.st_mtime, p))
+            except OSError:
+                continue
     except OSError:
         pass
-    return os.environ.get("DISPLAY", ":0")
+    candidates.sort(reverse=True)
+    return [p for _, p in candidates]
 
+
+def _detect_display(default: str = ":0") -> str:
+    """Return the live X display, preferring the most recently created socket.
+    Falls back to $DISPLAY then `default` if no live socket can be probed."""
+    live = _live_x_sockets()
+    if live:
+        return f":{live[0].name[1:]}"
+    return os.environ.get("DISPLAY", default)
+
+
+def _detect_wayland_display(default: str = "wayland-1") -> str:
+    """Return the most recent wayland-* socket name in $XDG_RUNTIME_DIR.
+    Falls back to $WAYLAND_DISPLAY then `default`."""
+    runtime = Path(XDG_RUNTIME_DIR)
+    try:
+        socks = sorted(
+            (p for p in runtime.iterdir() if p.name.startswith("wayland-") and p.is_socket()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if socks:
+            return socks[0].name
+    except OSError:
+        pass
+    return os.environ.get("WAYLAND_DISPLAY", default)
+
+
+def _wait_for_x_display(timeout: float = 30.0) -> str | None:
+    """Block until at least one live X socket appears, returning the display.
+    Returns None on timeout. Used at startup instead of a fixed sleep so the
+    broker doesn't race the desktop on slow hosts."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        live = _live_x_sockets()
+        if live:
+            return f":{live[0].name[1:]}"
+        time.sleep(0.25)
+    return None
+
+
+# LD_PRELOAD must include both the joystick interposer and the fake libudev
+# (the latter lets SDL discover the synthetic /dev/input/js* devices that the
+# linuxserver init creates via mknod). The base image normally exports it; if
+# it didn't, we fall back to the well-known paths but warn loudly so the
+# operator sees that gamepads may be silently broken.
+_LD_PRELOAD_DEFAULT = "/usr/lib/selkies_joystick_interposer.so:/opt/lib/libudev.so.1.0.0-fake"
+_LD_PRELOAD = os.environ.get("LD_PRELOAD") or _LD_PRELOAD_DEFAULT
+_LD_PRELOAD_FROM_ENV = "LD_PRELOAD" in os.environ and bool(os.environ["LD_PRELOAD"])
 
 ENV = {
     "DISPLAY":           _detect_display(),
-    "WAYLAND_DISPLAY":   "wayland-1",
-    "XDG_RUNTIME_DIR":   "/config/.XDG",
+    "WAYLAND_DISPLAY":   _detect_wayland_display(),
+    "XDG_RUNTIME_DIR":   XDG_RUNTIME_DIR,
     "PULSE_RUNTIME_PATH":"/defaults",
-    # LD_PRELOAD must include both the joystick interposer and the fake libudev
-    # — the latter lets SDL discover the synthetic /dev/input/js* devices that
-    # the linuxserver init script creates via mknod. Read from the container env
-    # to inherit whatever the base image set (currently both libs colon-separated).
-    "LD_PRELOAD":        os.environ.get("LD_PRELOAD", "/usr/lib/selkies_joystick_interposer.so:/opt/lib/libudev.so.1.0.0-fake"),
+    "LD_PRELOAD":        _LD_PRELOAD,
     "HOME":              "/config",
     "USER":              "abc",
     "QT_QPA_PLATFORM":   "xcb",
@@ -66,6 +124,21 @@ logging.basicConfig(
     stream=sys.stdout,
 )
 log = logging.getLogger("broker")
+
+# Warn if the linuxserver init didn't export LD_PRELOAD — gamepads silently
+# break when only the interposer is loaded without the fake libudev. Logged
+# here (after `log` exists) rather than at module import.
+if not _LD_PRELOAD_FROM_ENV:
+    log.warning(
+        "LD_PRELOAD not set in environment; falling back to %s. "
+        "If the linuxserver image moved these libraries, gamepads will not appear in PCSX2.",
+        _LD_PRELOAD_DEFAULT,
+    )
+
+# pcsx2-qt's own stdout/stderr is captured to this log so renderer/Vulkan/Qt
+# errors are visible after the fact. /config is the only host-mapped writable
+# path we can rely on.
+PCSX2_LOG_PATH = Path(os.environ.get("PCSX2_LOG_PATH", "/config/pcsx2-qt.log"))
 
 # ── Session state ─────────────────────────────────────────────────────────────
 
@@ -94,39 +167,108 @@ def _validate_rom_path(raw: str) -> Path | None:
 
 
 def _patch_ini():
+    """Force broker-required PCSX2.ini settings. Each key is scoped to its
+    expected section so identically-named keys in other sections aren't stomped.
+    Failures are logged loudly — silent failure here means PCSX2 launches with
+    the wrong PINE/Fullscreen/Shutdown settings and downstream features break."""
     if not INI_PATH.exists():
         log.warning("PCSX2.ini not found at %s — skipping patch", INI_PATH)
         return
+
+    # (section, key) → "key = value" line.
+    patches: dict[tuple[str, str], str] = {
+        ("EmuCore",      "EnablePINE"):          "EnablePINE = true",
+        ("UI",           "StartFullscreen"):     "StartFullscreen = true",
+        ("UI",           "ConfirmShutdown"):     "ConfirmShutdown = false",
+        ("EmuCore",      "SaveStateOnShutdown"): "SaveStateOnShutdown = false",
+    }
+
     try:
-        patches = {
-            "EnablePINE":           "EnablePINE = true",
-            "StartFullscreen":      "StartFullscreen = true",
-            "ConfirmShutdown":      "ConfirmShutdown = false",
-            "SaveStateOnShutdown":  "SaveStateOnShutdown = false",
-        }
         lines = INI_PATH.read_text().splitlines()
-        applied = set()
-        new_lines = []
+        section = ""
+        applied: set[tuple[str, str]] = set()
+        new_lines: list[str] = []
         for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                section = stripped[1:-1]
+                new_lines.append(line)
+                continue
             matched = False
-            for key, val in patches.items():
-                if line.strip().startswith(f"{key} =") or line.strip().startswith(f"{key}="):
+            for (sec, key), val in patches.items():
+                if section != sec:
+                    continue
+                if stripped.startswith(f"{key} =") or stripped.startswith(f"{key}="):
                     new_lines.append(val)
-                    applied.add(key)
+                    applied.add((sec, key))
                     matched = True
                     break
             if not matched:
                 new_lines.append(line)
-        for key, val in patches.items():
-            if key not in applied:
-                log.warning("PCSX2.ini: %s not found — appending without section header", key)
-                new_lines.append(val)
+
+        # Append missing keys under their target section header. If the section
+        # doesn't exist at all we create it so PCSX2 picks the value up.
+        missing = [(sec, key, val) for (sec, key), val in patches.items() if (sec, key) not in applied]
+        if missing:
+            present_sections = {l.strip()[1:-1] for l in new_lines if l.strip().startswith("[") and l.strip().endswith("]")}
+            for sec, _key, val in missing:
+                if sec in present_sections:
+                    # Insert immediately after the section header.
+                    out: list[str] = []
+                    inserted = False
+                    for l in new_lines:
+                        out.append(l)
+                        if not inserted and l.strip() == f"[{sec}]":
+                            out.append(val)
+                            inserted = True
+                    new_lines = out
+                else:
+                    new_lines.extend(["", f"[{sec}]", val])
+                    present_sections.add(sec)
+
         tmp = INI_PATH.with_suffix(".tmp")
         tmp.write_text("\n".join(new_lines) + "\n")
         tmp.replace(INI_PATH)  # atomic on POSIX; prevents partial-write corruption
         log.debug("PCSX2.ini patched (PINE, Fullscreen, NoConfirmShutdown, SaveStateOnShutdown)")
-    except Exception as exc:
-        log.error("Failed to patch PCSX2.ini: %s", exc)
+    except OSError as exc:
+        log.error("PCSX2.ini patch failed (filesystem): %s — broker settings NOT applied", exc)
+    except Exception:
+        log.exception("PCSX2.ini patch failed unexpectedly — broker settings NOT applied")
+
+
+def _read_initial_save_slot() -> int:
+    """Best-effort read of PCSX2's last-used save slot from PCSX2.ini.
+
+    PCSX2 persists the active save state slot in [EmuCore] under
+    `SaveStateSlot`. If the key is absent or the file is unreadable, fall
+    back to the BROKER_INITIAL_SLOT env var (default 1). Used by the launch
+    handler to seed the slot tracker so xdotool save-state cycling targets
+    the right slot on the first save after launch.
+    """
+    fallback = int(os.environ.get("BROKER_INITIAL_SLOT", "1"))
+    if not INI_PATH.exists():
+        return fallback
+    try:
+        section = ""
+        for raw in INI_PATH.read_text().splitlines():
+            line = raw.strip()
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1]
+                continue
+            if section != "EmuCore":
+                continue
+            if line.startswith("SaveStateSlot =") or line.startswith("SaveStateSlot="):
+                _, _, value = line.partition("=")
+                try:
+                    n = int(value.strip())
+                except ValueError:
+                    return fallback
+                if 1 <= n <= 10:
+                    return n
+                return fallback
+    except OSError as exc:
+        log.debug("Could not read SaveStateSlot from PCSX2.ini: %s", exc)
+    return fallback
 
 
 def _kill_pcsx2():
@@ -168,25 +310,51 @@ def _launch_pcsx2_internal(rom_path):
     log.info("Launching PCSX2 (rom=%s)", rom_path or "dashboard")
     log.debug("Launching: %s", " ".join(cmd))
 
+    # Open the pcsx2-qt log in append mode so we keep history across launches.
+    # Failure to open it is non-fatal: emulator still launches, just without
+    # captured output. We try to keep the file under abc:abc so pcsx2-qt can
+    # write to it after sudo drops privileges.
+    try:
+        log_fh = open(PCSX2_LOG_PATH, "ab", buffering=0)
+        try:
+            os.chown(PCSX2_LOG_PATH, 1000, 1000)  # abc uid/gid in linuxserver images
+        except (OSError, PermissionError):
+            pass
+        log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} launch (rom={rom_path or 'dashboard'}) ===\n".encode())
+        log_fh.flush()
+    except OSError as exc:
+        log.warning("Cannot open %s for pcsx2-qt output capture (%s); continuing without capture.", PCSX2_LOG_PATH, exc)
+        log_fh = None
+
     try:
         proc = subprocess.Popen(
             cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=log_fh if log_fh else subprocess.DEVNULL,
+            stderr=subprocess.STDOUT if log_fh else subprocess.DEVNULL,
             preexec_fn=os.setpgrp,  # own process group so killpg is clean
         )
-    except Exception as exc:
+    except OSError as exc:
         log.error("Failed to launch PCSX2: %s", exc)
+        if log_fh:
+            log_fh.close()
         with _session_lock:
             _session["process"] = None
             _session["is_managed"] = False
         return
+    finally:
+        # Popen dup'd the fd; we can close our handle so it's not leaked.
+        if log_fh:
+            log_fh.close()
 
+    initial_slot = _read_initial_save_slot()
     with _session_lock:
         _session["process"] = proc
         _session["is_managed"] = True
-        _session["current_slot"] = 1  # PCSX2 always starts at slot 1
-    log.info("PCSX2 launched (PID %d)", proc.pid)
+        # PCSX2's persisted slot from PCSX2.ini, or BROKER_INITIAL_SLOT.
+        # We can't query PCSX2 for its live slot, so this is a best-effort seed
+        # that tracks the same value PCSX2 itself loads on startup.
+        _session["current_slot"] = initial_slot
+    log.info("PCSX2 launched (PID %d, initial save slot %d)", proc.pid, initial_slot)
     Thread(target=_monitor_process, args=(proc, time.monotonic()), daemon=True).start()
 
 
@@ -212,7 +380,9 @@ def _monitor_process(proc, start_time):
             return
         _session["rom_path"] = None
         _session["rom_name"] = "Dashboard"
-        _session["started_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        # Dashboard is an idle state, not a session; clearing started_at lets
+        # /status reliably distinguish "playing" from "not playing".
+        _session["started_at"] = None
 
     _launch_pcsx2_internal(None)
 
@@ -262,15 +432,33 @@ def _drain_gamepad_sockets():
     )
 
 
+def _wait_for_no_pcsx2(timeout: float = 3.0) -> bool:
+    """Block until no `pcsx2-qt` process is running, up to `timeout` seconds.
+    Returns True if the process is gone, False on timeout. This replaces a
+    fixed sleep that papered over residual processes after _kill_pcsx2."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(["pgrep", "-x", "pcsx2-qt"], capture_output=True)
+        if result.returncode != 0:  # pgrep exits 1 when no process matches
+            return True
+        time.sleep(0.1)
+    return False
+
+
 def _launch_pcsx2(rom_path):
     _kill_pcsx2()
     _drain_gamepad_sockets()
     _patch_ini()
-    time.sleep(2)  # let drained handlers exit and the kill settle before launching
+    if not _wait_for_no_pcsx2():
+        log.warning("pcsx2-qt still running after kill+drain; relaunching anyway")
     with _session_lock:
         _session["rom_path"] = rom_path
         _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
-        _session["started_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        # Only stamp a session start when an actual ROM is being played. The
+        # dashboard is an idle state.
+        _session["started_at"] = (
+            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
+        )
     _launch_pcsx2_internal(rom_path)
 
 
@@ -398,8 +586,17 @@ def _pine_save_state(slot: int) -> bool:
             log.info("PINE: save command sent (slot %d) — waiting for write (max %.1fs)", slot, PINE_WAIT)
             deadline = time.monotonic() + PINE_WAIT
             ok = _wait_for_sstate_write(before, deadline)
-    except Exception as exc:
-        log.error("PINE save state (slot %d) failed to send: %s", slot, exc)
+    except FileNotFoundError:
+        log.error("PINE save state (slot %d): socket %s vanished between discovery and connect", slot, socket_path)
+        return False
+    except ConnectionRefusedError:
+        log.error("PINE save state (slot %d): connection refused on %s — PCSX2 may have just exited", slot, socket_path)
+        return False
+    except _socket.timeout:
+        log.error("PINE save state (slot %d): timed out (>%.1fs) connecting/sending to %s", slot, PINE_TIMEOUT, socket_path)
+        return False
+    except OSError as exc:
+        log.error("PINE save state (slot %d): %s on %s (errno=%s)", slot, type(exc).__name__, socket_path, exc.errno)
         return False
 
     if not ok:
@@ -431,6 +628,7 @@ def _xdotool_find_window() -> str | None:
         + ["xdotool"]
     )
 
+    last_search_err: str | None = None
     for pid in pids:
         try:
             out = subprocess.check_output(
@@ -441,10 +639,16 @@ def _xdotool_find_window() -> str | None:
                 wid = ids[-1]  # last window is the main game surface
                 log.debug("xdotool: found window %s for PID %s", wid, pid)
                 return wid
-        except Exception as exc:
-            log.debug("xdotool: window search failed for PID %s: %s", pid, exc)
+        except subprocess.CalledProcessError as exc:
+            # Non-zero from xdotool = no match for this PID; expected during
+            # the brief period before the main window is mapped.
+            last_search_err = f"PID {pid}: exit {exc.returncode}"
+        except subprocess.TimeoutExpired:
+            log.warning("xdotool: search timed out for PID %s (X server slow or hung)", pid)
+        except OSError as exc:
+            log.warning("xdotool: failed to invoke for PID %s: %s", pid, exc)
 
-    # Fallback: search by class name
+    # Fallback: search by class name (case where window has no _NET_WM_PID).
     try:
         out = subprocess.check_output(
             xdo_base + ["search", "--onlyvisible", "--classname", "pcsx2-qt"], text=True, timeout=5,
@@ -454,10 +658,17 @@ def _xdotool_find_window() -> str | None:
             wid = ids[-1]
             log.debug("xdotool: found window %s by classname fallback", wid)
             return wid
-    except Exception as exc:
-        log.debug("xdotool: classname search failed: %s", exc)
+    except subprocess.CalledProcessError as exc:
+        last_search_err = f"classname: exit {exc.returncode}"
+    except subprocess.TimeoutExpired:
+        log.warning("xdotool: classname search timed out (X server slow or hung)")
+    except OSError as exc:
+        log.warning("xdotool: classname fallback failed to invoke: %s", exc)
 
-    log.error("xdotool: PCSX2 window not found")
+    log.warning(
+        "xdotool: PCSX2 window not found (PIDs %s, last error: %s) — F-key shortcuts will not be delivered",
+        pids, last_search_err,
+    )
     return None
 
 
@@ -491,8 +702,18 @@ def _xdotool_cycle_to_slot(wid: str, slot: int) -> bool:
             subprocess.run(
                 xdo_cmd + ["key", "--window", wid, key], timeout=5, check=True
             )
-        except Exception as exc:
-            log.error("xdotool: slot cycle failed: %s", exc)
+        except subprocess.CalledProcessError as exc:
+            log.error("xdotool: slot cycle keypress failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
+            with _session_lock:
+                _session["current_slot"] = current
+            return False
+        except subprocess.TimeoutExpired:
+            log.error("xdotool: slot cycle keypress timed out (window %s, key %s)", wid, key)
+            with _session_lock:
+                _session["current_slot"] = current
+            return False
+        except OSError as exc:
+            log.error("xdotool: failed to invoke for slot cycle: %s", exc)
             with _session_lock:
                 _session["current_slot"] = current
             return False
@@ -534,8 +755,14 @@ def _xdotool_save_state(slot: int) -> bool:
     )
     try:
         subprocess.run(xdo_cmd + ["key", "--window", wid, "F1"], timeout=5, check=True)
-    except Exception as exc:
-        log.error("xdotool: save key failed: %s", exc)
+    except subprocess.CalledProcessError as exc:
+        log.error("xdotool: F1 send failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        log.error("xdotool: F1 send timed out on window %s", wid)
+        return False
+    except OSError as exc:
+        log.error("xdotool: failed to invoke for F1: %s", exc)
         return False
 
     log.info(
@@ -564,8 +791,14 @@ def _xdotool_load_state(slot: int) -> bool:
     )
     try:
         subprocess.run(xdo_cmd + ["key", "--window", wid, "F3"], timeout=5, check=True)
-    except Exception as exc:
-        log.error("xdotool: load key failed: %s", exc)
+    except subprocess.CalledProcessError as exc:
+        log.error("xdotool: F3 send failed (exit %d, stderr=%s)", exc.returncode, exc.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        log.error("xdotool: F3 send timed out on window %s", wid)
+        return False
+    except OSError as exc:
+        log.error("xdotool: failed to invoke for F3: %s", exc)
         return False
 
     log.info("xdotool: F3 sent to window %s (slot %d)", wid, slot)
@@ -726,6 +959,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 # Relaunch to dashboard regardless of save result — PCSX2 is already dead.
                 Thread(target=_launch_pcsx2, args=(None,), daemon=True).start()
             else:
+                # Clear visible session state synchronously so that callers
+                # polling /status immediately after this response observe
+                # "no game running" instead of stale rom_path. The background
+                # thread still runs the actual save+kill+relaunch.
+                with _session_lock:
+                    _session["rom_path"] = None
+                    _session["rom_name"] = "Dashboard"
+                    _session["started_at"] = None
+
                 def _bg(s):
                     try:
                         ok = _save_and_exit(s)
@@ -737,8 +979,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     # Relaunch to dashboard regardless of save result — PCSX2 is already dead.
                     _launch_pcsx2(None)
                 Thread(target=_bg, args=(slot,), daemon=True).start()
-                # Session state is not yet cleared when this response is sent;
-                # callers polling /status immediately may observe stale state.
                 self._send_json(200, {"status": "queued", "slot": slot})
             return
 
@@ -810,7 +1050,17 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 self._send_json(400, {"error": "slot must be 1–10"})
                 return
             ok = _xdotool_load_state(slot)
-            self._send_json(200 if ok else 500, {"status": "ok" if ok else "error", "loaded": ok, "slot": slot})
+            if ok:
+                self._send_json(200, {"status": "ok", "loaded": True, "slot": slot})
+            else:
+                # 503: PCSX2 is the upstream and we couldn't reach its window
+                # (xdotool find/dispatch failed). The broker itself is healthy.
+                self._send_json(503, {
+                    "status": "error",
+                    "loaded": False,
+                    "slot": slot,
+                    "error": "could not deliver F3 to PCSX2 window (window not found or xdotool failure)",
+                })
             return
 
         if self.path != "/launch":
@@ -865,16 +1115,50 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
+    """Stop the HTTP listener, finish any in-flight save, then kill PCSX2.
+    Triggered on SIGTERM/SIGINT so `systemctl stop` doesn't drop a save mid-write."""
+    log.info("Received signal %d — beginning graceful shutdown", signum)
+    # Stop accepting new requests immediately so /save-and-exit can't race us.
+    Thread(target=server.shutdown, daemon=True).start()
+
+    # Wait briefly for any in-flight save to finish. The /save-and-exit handler
+    # holds save_in_progress for the duration of the F1+poll cycle.
+    deadline = time.monotonic() + max(PINE_WAIT, 5.0)
+    while time.monotonic() < deadline:
+        with _session_lock:
+            if not _session["save_in_progress"]:
+                break
+        time.sleep(0.2)
+    else:
+        log.warning("Shutdown: in-flight save did not complete within %.1fs — killing PCSX2 anyway", PINE_WAIT)
+
+    _kill_pcsx2()
+    log.info("Shutdown complete")
+
+
 def main():
-    log.info("Broker starting — waiting 5s for desktop...")
-    time.sleep(5)
+    log.info("Broker starting — waiting for desktop X display...")
+    display = _wait_for_x_display(timeout=30.0)
+    if display is None:
+        log.error("No live X display appeared within 30s; pcsx2-qt will likely fail to launch")
+    else:
+        # Update ENV in case the display we found is different from the one
+        # we detected at module load time (Xvfb may not be up yet then).
+        ENV["DISPLAY"] = display
+        _XDOTOOL_ENV["DISPLAY"] = display
+        log.info("Desktop ready on DISPLAY=%s", display)
 
     # Safety net for stale processes on hot-reload; init-pcsx2-config already
     # disables the labwc autostart so this should normally find nothing.
-    result = subprocess.run(["pkill", "-9", "-f", "pcsx2-qt"], capture_output=True)
+    # -x: match the binary name exactly. -f matches the entire command line and
+    # would also kill processes that merely *mention* "pcsx2-qt" (editors, shells,
+    # log tailers, etc.).
+    result = subprocess.run(["pkill", "-9", "-x", "pcsx2-qt"], capture_output=True)
     if result.returncode == 0:
         log.info("Killed stale pcsx2-qt instance(s) on startup.")
-        time.sleep(2)
+        if not _wait_for_no_pcsx2(timeout=3.0):
+            log.warning("Stale pcsx2-qt instance still running after SIGKILL — OS may be slow")
 
     _patch_ini()
     _launch_pcsx2_internal(None)
@@ -884,9 +1168,18 @@ def main():
     if SECRET:
         log.info("Shared secret auth enabled")
 
+    # Install a single handler for both SIGTERM (systemd stop) and SIGINT
+    # (Ctrl-C). We intentionally don't use server.serve_forever()'s default
+    # KeyboardInterrupt path because it doesn't cover SIGTERM.
+    def _handle(signum, _frame):
+        _graceful_shutdown(server, signum)
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
     try:
         server.serve_forever()
-    except KeyboardInterrupt:
+    finally:
         server.server_close()
 
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -1295,11 +1295,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
             SECRET,
         )
 
-    def _send_json(self, code: int, body: dict) -> None:
+    def _send_json(self, code: int, body: dict, headers: dict | None = None) -> None:
         payload = json.dumps(body).encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
         self.end_headers()
         self.wfile.write(payload)
 
@@ -1402,7 +1404,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(409, {"error": result})
             return
         if result is None:
-            self._send_json(404, {"error": "no folder memory card in slot 1"})
+            # Tag the "slot is empty" 404 so the backend can tell a genuinely
+            # empty card apart from a missing endpoint (an unmarked 404), which
+            # must NOT be treated as safe-to-wipe.
+            self._send_json(
+                404,
+                {"error": "no folder memory card in slot 1"},
+                headers={"X-Memory-Card": "absent"},
+            )
             return
         self.send_response(200)
         self.send_header("Content-Type", "application/zip")

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -3,6 +3,7 @@
 
 import glob
 import hmac
+import io
 import json
 import logging
 import os
@@ -12,8 +13,9 @@ import struct
 import subprocess
 import sys
 import time
+import zipfile
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from threading import Thread, Lock
 from urllib.parse import parse_qs, urlparse
 
@@ -161,6 +163,10 @@ _session: dict = {
     "save_in_progress": False,
     "launch_in_progress": False,  # guards against concurrent /launch requests
     "current_slot":     1,      # tracks PCSX2's active save state slot (resets to 1 on each launch)
+    # Wall-clock stamp of the last GAME launch (not dashboard relaunches).
+    # GET /save-file only ships files modified at or after this point; it
+    # survives game exit so RomM can still pull after the session ends.
+    "save_baseline":    None,
 }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -480,6 +486,10 @@ def _launch_pcsx2(rom_path, release_claim=False):
             _session["started_at"] = (
                 time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
             )
+            # Dashboard relaunches keep the previous baseline so an end-of-session
+            # save pull still sees the files the last game wrote.
+            if rom_path:
+                _session["save_baseline"] = time.time()
         _launch_pcsx2_internal(rom_path)
     finally:
         # Only the caller that claimed launch_in_progress (POST /launch) may
@@ -986,6 +996,146 @@ def _pactl_get_mute() -> bool | None:
     return result.stdout.strip().endswith("yes")
 
 
+# ── In-game save sync ─────────────────────────────────────────────────────────
+# Alongside the savestate sync above, RomM syncs PCSX2's memory cards. GET
+# /save-file zips every memcard file modified since the last game launch; PUT
+# /save-file restores a pulled archive before launch. The mtime last-write-wins
+# guard is what keeps an old pulled card from clobbering a newer local one.
+_SAVE_DATA_ROOTS = (
+    Path("/config/.config/PCSX2"),
+)
+# Archive members must live under one of these root-relative subtrees; PUT
+# rejects anything else so a crafted zip cannot reach configs or savestates.
+SAVE_SYNC_SUBTREES = ("memcards",)
+SAVE_FILE_MAX_BYTES = 256 * 1024 * 1024
+# Zip stores mtimes at 2 s DOS resolution; the slack keeps the newer-file
+# guard from skipping files over rounding alone.
+_SAVE_MTIME_SLACK = 2.0
+
+
+def _save_data_root() -> Path | None:
+    """Return PCSX2's config dir, honouring a SAVE_DATA_ROOT override."""
+    env = os.environ.get("SAVE_DATA_ROOT")
+    if env:
+        return Path(env)
+    for c in _SAVE_DATA_ROOTS:
+        if c.is_dir():
+            return c
+    return None
+
+
+def _iter_save_files(root: Path) -> list[Path]:
+    """Every regular file under the allowed save subtrees, sorted for a
+    deterministic archive (identical content zips to identical bytes)."""
+    files: list[Path] = []
+    for sub in SAVE_SYNC_SUBTREES:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        files.extend(
+            p for p in sorted(base.rglob("*")) if p.is_file() and not p.is_symlink()
+        )
+    return files
+
+
+def _build_save_archive(baseline: float) -> bytes | None:
+    """Zip every save file modified since the last game launch.
+
+    Returns None when there is nothing to sync — no data dir yet, or no file
+    changed since `baseline`. Member paths are relative to the data dir so a
+    later PUT restores them regardless of which candidate dir is live."""
+    root = _save_data_root()
+    if root is None:
+        log.debug("save-file: no PCSX2 data dir found")
+        return None
+    changed: list[Path] = []
+    total = 0
+    for p in _iter_save_files(root):
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if st.st_mtime >= baseline:
+            changed.append(p)
+            total += st.st_size
+    if not changed:
+        return None
+    if total > SAVE_FILE_MAX_BYTES:
+        log.warning("save-file: changed saves exceed size limit (%d bytes)", total)
+        return None
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in changed:
+            try:
+                zf.write(p, p.relative_to(root).as_posix())
+            except OSError as exc:
+                log.warning("save-file: could not read %s — %s", p, exc)
+    return buf.getvalue()
+
+
+def _mkdirs_owned(path: Path) -> None:
+    """mkdir -p with abc ownership on every directory this call creates, so
+    PCSX2 (running as abc) can keep writing saves inside them later."""
+    missing: list[Path] = []
+    cur = path
+    while not cur.exists():
+        missing.append(cur)
+        cur = cur.parent
+    path.mkdir(parents=True, exist_ok=True)
+    for d in reversed(missing):
+        try:
+            os.chown(d, _LOG_UID, _LOG_GID)
+        except OSError:
+            pass
+
+
+def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
+    """Restore a pulled save archive into the data dir.
+
+    Returns (written, skipped) on success, or an error string for a bad
+    archive. Existing files newer than their archive member are skipped so a
+    restore can never roll back saves made since the archive was taken."""
+    root = _save_data_root() or _SAVE_DATA_ROOTS[0]
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        return "body is not a zip archive"
+    with zf:
+        infos = [i for i in zf.infolist() if not i.is_dir()]
+        if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
+            return "archive exceeds size limit when extracted"
+        for info in infos:
+            member = PurePosixPath(info.filename)
+            if member.is_absolute() or ".." in member.parts:
+                return f"archive member escapes save dir: {info.filename}"
+            if not any(
+                member.as_posix().startswith(sub + "/") for sub in SAVE_SYNC_SUBTREES
+            ):
+                return f"archive member outside save subtrees: {info.filename}"
+
+        written = skipped = 0
+        for info in infos:
+            target = root / PurePosixPath(info.filename)
+            mtime = time.mktime(info.date_time + (0, 0, -1))
+            try:
+                if (
+                    target.exists()
+                    and target.stat().st_mtime > mtime + _SAVE_MTIME_SLACK
+                ):
+                    skipped += 1
+                    continue
+                _mkdirs_owned(target.parent)
+                tmp = target.parent / f".{target.name}.tmp"
+                tmp.write_bytes(zf.read(info))
+                os.chown(tmp, _LOG_UID, _LOG_GID)
+                os.replace(tmp, target)
+                os.utime(target, (mtime, mtime))
+            except OSError as exc:
+                return f"could not write {info.filename}: {exc}"
+            written += 1
+    return (written, skipped)
+
+
 # ── HTTP handler ──────────────────────────────────────────────────────────────
 
 class BrokerHandler(BaseHTTPRequestHandler):
@@ -1058,11 +1208,57 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.wfile.write(content)
         log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
 
+    def _get_save_file(self):
+        with _session_lock:
+            baseline = _session["save_baseline"]
+            rom_name = _session["rom_name"]
+        if baseline is None:
+            self._send_json(404, {"error": "no game has been launched"})
+            return
+        archive = _build_save_archive(baseline)
+        if archive is None:
+            self._send_json(404, {"error": "no save changes since last launch"})
+            return
+        # Header values must be latin-1; ROM stems can be anything.
+        safe_name = "".join(
+            c for c in (rom_name or "pcsx2") if c.isascii() and c.isprintable()
+        ).strip() or "pcsx2"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/zip")
+        self.send_header("Content-Length", str(len(archive)))
+        self.send_header("X-Save-Filename", f"{safe_name}.saves.zip")
+        self.end_headers()
+        self.wfile.write(archive)
+        log.info("save-file: served archive (%d bytes)", len(archive))
+
+    def _put_save_file(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or empty body"})
+            return
+        if length > SAVE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "archive too large"})
+            return
+        content = self.rfile.read(length)
+        result = _extract_save_archive(content)
+        if isinstance(result, str):
+            self._send_json(400, {"error": result})
+            return
+        written, skipped = result
+        log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
+        self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
+
     def do_PUT(self):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
             return
         parsed = urlparse(self.path)
+        if parsed.path == "/save-file":
+            self._put_save_file()
+            return
         if parsed.path != "/state-file":
             self._send_json(404, {"error": "not found"})
             return
@@ -1116,6 +1312,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(403, {"error": "forbidden"})
         elif urlparse(self.path).path == "/state-file":
             self._get_state_file()
+        elif urlparse(self.path).path == "/save-file":
+            self._get_save_file()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -26,6 +26,10 @@ PORT     = int(os.environ.get("BROKER_PORT", "8000"))
 SECRET   = os.environ.get("BROKER_SECRET", "")
 ROM_ROOT = Path(os.environ.get("ROM_ROOT", "/romm/library")).resolve()
 
+# JSON request bodies are tiny (a rom_path, a slot number); anything larger
+# is rejected with 413 rather than silently truncated.
+_BODY_MAX_BYTES = 64 * 1024
+
 XDG_RUNTIME_DIR = "/config/.XDG"
 
 
@@ -895,8 +899,11 @@ def _xdotool_save_state(slot: int) -> bool:
     )
     deadline = time.monotonic() + PINE_WAIT
     if not _wait_for_sstate_write(before, deadline):
+        # Same contract as _pine_save_state: an unconfirmed write is a failed
+        # save, so callers never report saved=true for a state that may not exist.
         log.warning("xdotool: save state write not confirmed within %.1fs (F1 was sent)", PINE_WAIT)
-    return True  # F1 was delivered; write detection is best-effort confirmation
+        return False
+    return True
 
 
 def _xdotool_load_state(slot: int) -> bool:
@@ -1039,12 +1046,41 @@ def _iter_save_files(root: Path) -> list[Path]:
     return files
 
 
-def _build_save_archive(baseline: float) -> bytes | None:
+def _read_file_stable(
+    p: Path, retries: int = 4, settle: float = 0.5
+) -> tuple[bytes, float] | None:
+    """Read `p` only when its size/mtime are identical before and after the
+    read, so a file PCSX2 is mid-writing is never shipped torn. Returns
+    (contents, mtime), or None when the file stays unstable through every
+    retry or cannot be read."""
+    for attempt in range(retries):
+        try:
+            st_before = p.stat()
+            data = p.read_bytes()
+            st_after = p.stat()
+        except OSError as exc:
+            log.warning("save-file: could not read %s — %s", p, exc)
+            return None
+        if (st_before.st_size, st_before.st_mtime_ns) == (
+            st_after.st_size,
+            st_after.st_mtime_ns,
+        ):
+            return data, st_after.st_mtime
+        if attempt < retries - 1:
+            time.sleep(settle)
+    log.warning("save-file: %s still being written — skipped this pull", p)
+    return None
+
+
+def _build_save_archive(baseline: float) -> tuple[bytes, int] | None | str:
     """Zip every save file modified since the last game launch.
 
-    Returns None when there is nothing to sync — no data dir yet, or no file
-    changed since `baseline`. Member paths are relative to the data dir so a
-    later PUT restores them regardless of which candidate dir is live."""
+    Returns (zip_bytes, skipped) — `skipped` counts files left out because
+    they were unreadable or still being written — None when there is nothing
+    to sync (no data dir yet, or no file changed since `baseline`), or an
+    error string when the changed set exceeds the size limit. Member paths
+    are relative to the data dir so a later PUT restores them regardless of
+    which candidate dir is live."""
     root = _save_data_root()
     if root is None:
         log.debug("save-file: no PCSX2 data dir found")
@@ -1063,15 +1099,22 @@ def _build_save_archive(baseline: float) -> bytes | None:
         return None
     if total > SAVE_FILE_MAX_BYTES:
         log.warning("save-file: changed saves exceed size limit (%d bytes)", total)
-        return None
+        return f"changed saves exceed size limit ({total} bytes)"
     buf = io.BytesIO()
+    skipped = 0
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for p in changed:
-            try:
-                zf.write(p, p.relative_to(root).as_posix())
-            except OSError as exc:
-                log.warning("save-file: could not read %s — %s", p, exc)
-    return buf.getvalue()
+            result = _read_file_stable(p)
+            if result is None:
+                skipped += 1
+                continue
+            data, mtime = result
+            info = zipfile.ZipInfo(
+                p.relative_to(root).as_posix(),
+                date_time=time.localtime(mtime)[:6],
+            )
+            zf.writestr(info, data, zipfile.ZIP_DEFLATED)
+    return buf.getvalue(), skipped
 
 
 def _mkdirs_owned(path: Path) -> None:
@@ -1273,10 +1316,17 @@ def _replace_memory_card(content: bytes) -> tuple[int] | str:
                 try:
                     os.replace(backup, path)
                 except OSError:
-                    log.error("memory-card: could not restore card to %s", path)
-            return f"could not write memory card: {exc}"
-        finally:
+                    # The backup is now the only surviving copy of the card —
+                    # leave it on disk for manual recovery instead of deleting it.
+                    log.error(
+                        "memory-card: could not restore card to %s — old card preserved at %s",
+                        path,
+                        backup,
+                    )
+                    return f"could not write memory card: {exc}"
             shutil.rmtree(backup, ignore_errors=True)
+            return f"could not write memory card: {exc}"
+        shutil.rmtree(backup, ignore_errors=True)
     return (written,)
 
 
@@ -1305,17 +1355,29 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
-    def _read_body(self) -> dict:
+    def _read_body(self) -> dict | None:
+        """Parse the JSON request body. Returns {} for an absent body. Sends
+        the error response itself and returns None when the body is oversized
+        or not a JSON object — callers must bail out on None."""
         try:
-            length = max(0, min(int(self.headers.get("Content-Length", 0)), 64 * 1024))
+            length = int(self.headers.get("Content-Length", 0))
         except ValueError:
             length = 0
-        if length == 0:
+        if length <= 0:
             return {}
+        if length > _BODY_MAX_BYTES:
+            self._send_json(413, {"error": "request body too large"})
+            return None
+        raw = self.rfile.read(length)
         try:
-            return json.loads(self.rfile.read(length))
+            body = json.loads(raw)
         except json.JSONDecodeError:
-            return {}
+            self._send_json(400, {"error": "body is not valid JSON"})
+            return None
+        if not isinstance(body, dict):
+            self._send_json(400, {"error": "body must be a JSON object"})
+            return None
+        return body
 
     def _get_state_file(self):
         query = parse_qs(urlparse(self.path).query)
@@ -1361,10 +1423,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if baseline is None:
             self._send_json(404, {"error": "no game has been launched"})
             return
-        archive = _build_save_archive(baseline)
-        if archive is None:
+        result = _build_save_archive(baseline)
+        if result is None:
             self._send_json(404, {"error": "no save changes since last launch"})
             return
+        if isinstance(result, str):
+            self._send_json(413, {"error": result})
+            return
+        archive, unstable = result
         # Header values must be latin-1; ROM stems can be anything.
         safe_name = "".join(
             c for c in (rom_name or "pcsx2") if c.isascii() and c.isprintable()
@@ -1373,9 +1439,16 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/zip")
         self.send_header("Content-Length", str(len(archive)))
         self.send_header("X-Save-Filename", f"{safe_name}.saves.zip")
+        if unstable:
+            # Files skipped mid-write; the caller can tell this pull was partial.
+            self.send_header("X-Save-Skipped-Unstable", str(unstable))
         self.end_headers()
         self.wfile.write(archive)
-        log.info("save-file: served archive (%d bytes)", len(archive))
+        log.info(
+            "save-file: served archive (%d bytes, %d unstable skipped)",
+            len(archive),
+            unstable,
+        )
 
     def _put_save_file(self):
         try:
@@ -1500,19 +1573,20 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self._send_json(200, {"status": "ok", "filename": filename})
 
     def do_GET(self):
-        if self.path == "/health":
+        path = urlparse(self.path).path
+        if path == "/health":
             self._send_json(200, {"status": "ok"})
         elif not self._check_secret():
             # /health stays open for container healthchecks; all other GETs
             # require the shared secret, matching POST/DELETE.
             self._send_json(403, {"error": "forbidden"})
-        elif urlparse(self.path).path == "/state-file":
+        elif path == "/state-file":
             self._get_state_file()
-        elif urlparse(self.path).path == "/save-file":
+        elif path == "/save-file":
             self._get_save_file()
-        elif urlparse(self.path).path == "/memory-card":
+        elif path == "/memory-card":
             self._get_memory_card()
-        elif self.path == "/status":
+        elif path == "/status":
             with _session_lock:
                 active = (
                     _session["process"] is not None
@@ -1548,6 +1622,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
+            if body is None:
+                with _session_lock:
+                    _session["save_in_progress"] = False
+                return
             slot = body.get("slot", SAVE_SLOT)
             if not isinstance(slot, int) or not (0 <= slot <= 10):
                 with _session_lock:
@@ -1595,6 +1673,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         if self.path == "/volume":
             body = self._read_body()
+            if body is None:
+                return
             level = body.get("level")
             if not isinstance(level, int) or not (0 <= level <= 100):
                 self._send_json(400, {"error": "level must be an integer 0–100"})
@@ -1609,6 +1689,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         if self.path == "/mute":
             body = self._read_body()
+            if body is None:
+                return
             if "mute" in body:
                 mute_arg = "1" if body["mute"] else "0"
             else:
@@ -1632,6 +1714,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
+            if body is None:
+                with _session_lock:
+                    _session["save_in_progress"] = False
+                return
             slot = body.get("slot", 1)
             if not isinstance(slot, int) or not (1 <= slot <= 10):
                 with _session_lock:
@@ -1656,6 +1742,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     self._send_json(409, {"error": "no game is running"})
                     return
             body = self._read_body()
+            if body is None:
+                return
             slot = body.get("slot", 1)
             if not isinstance(slot, int) or not (1 <= slot <= 10):
                 self._send_json(400, {"error": "slot must be 1–10"})
@@ -1679,6 +1767,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return
 
         body = self._read_body()
+        if body is None:
+            return
         raw_path = body.get("rom_path", "").strip()
 
         if not raw_path:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Unit tests for broker.py.
+
+Development-only — excluded from the Docker image via .dockerignore. Run from
+the repo root with the stdlib runner (no pytest, no dependencies):
+
+    python3 -m unittest discover -s tests -v
+
+These cover the pure logic: save/memory-card archive handling, INI parsing,
+and the session lifecycle state machine. Anything needing a real X display,
+PINE socket, or pcsx2-qt process is out of scope and only provable on the
+container.
+"""
+
+import io
+import os
+import sys
+import tempfile
+import time
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / "root" / "root")
+)
+
+import broker  # noqa: E402
+
+# The broker logs at INFO on import and throughout; tests assert on state, not
+# output, so keep the runner readable.
+broker.log.setLevel("CRITICAL")
+
+
+def _reset_session(**overrides):
+    """Return _session to a known idle state, then apply overrides."""
+    broker._session.update({
+        "process": None,
+        "rom_path": None,
+        "rom_name": None,
+        "started_at": None,
+        "is_managed": False,
+        "save_in_progress": False,
+        "launch_in_progress": False,
+        "launch_seq": 0,
+        "card_op_in_progress": False,
+        "relaunch_abandoned": False,
+        "current_slot": 1,
+        "save_baseline": None,
+    })
+    broker._session.update(overrides)
+    broker._rapid_exits = 0
+
+
+class _TempRootMixin:
+    """Gives each test an isolated PCSX2 data dir with chown stubbed out
+    (the suite does not run as root)."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.root, ignore_errors=True))
+        os.environ["SAVE_DATA_ROOT"] = str(self.root)
+        self.addCleanup(os.environ.pop, "SAVE_DATA_ROOT", None)
+        patcher = mock.patch.object(broker.os, "chown", lambda *a, **k: None)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.memcards = self.root / "memcards"
+
+    def _write(self, rel, data=b"x", mtime=None):
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+        if mtime is not None:
+            os.utime(p, (mtime, mtime))
+        return p
+
+    @staticmethod
+    def _zip(members):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for name, data in members.items():
+                zf.writestr(name, data)
+        return buf.getvalue()
+
+
+class SaveArchiveTests(_TempRootMixin, unittest.TestCase):
+
+    def test_round_trip_restores_content_and_tree(self):
+        self._write("memcards/Mcd001/BASLUS-1/save.bin", b"G" * 2048)
+        self._write("memcards/Mcd001/_pcsx2_superblock", b"S" * 512)
+        archive, skipped = broker._build_save_archive(time.time() - 10)
+        self.assertEqual(skipped, 0)
+
+        __import__("shutil").rmtree(self.memcards)
+        self.assertEqual(broker._extract_save_archive(archive), (2, 0, 0))
+        self.assertEqual(
+            (self.memcards / "Mcd001" / "BASLUS-1" / "save.bin").read_bytes(), b"G" * 2048
+        )
+
+    def test_only_files_newer_than_baseline_are_shipped(self):
+        self._write("memcards/old.bin", b"old", mtime=time.time() - 3600)
+        self._write("memcards/new.bin", b"new")
+        archive, _ = broker._build_save_archive(time.time() - 60)
+        with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+            self.assertEqual(zf.namelist(), ["memcards/new.bin"])
+
+    def test_no_changes_since_baseline_returns_none(self):
+        self._write("memcards/a.bin", b"a", mtime=time.time() - 3600)
+        self.assertIsNone(broker._build_save_archive(time.time()))
+
+    def test_missing_data_dir_returns_none(self):
+        os.environ["SAVE_DATA_ROOT"] = str(self.root / "nope")
+        self.assertIsNone(broker._build_save_archive(0))
+
+    def test_dot_prefixed_staging_files_are_never_swept_in(self):
+        self._write("memcards/real.bin", b"r")
+        self._write("memcards/.Mcd001.new-123/leftover.bin", b"junk")
+        self._write("memcards/.hidden.tmp", b"junk")
+        archive, _ = broker._build_save_archive(time.time() - 60)
+        with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+            self.assertEqual(zf.namelist(), ["memcards/real.bin"])
+
+    def test_restore_skips_files_newer_than_archive(self):
+        self._write("memcards/card.bin", b"archived")
+        archive, _ = broker._build_save_archive(time.time() - 10)
+        # Local copy is newer than the archive member: must not be rolled back.
+        future = time.time() + 3600
+        self._write("memcards/card.bin", b"LOCAL", mtime=future)
+        written, skipped, failed = broker._extract_save_archive(archive)
+        self.assertEqual((written, skipped, failed), (0, 1, 0))
+        self.assertEqual((self.memcards / "card.bin").read_bytes(), b"LOCAL")
+
+    def test_restore_is_timezone_independent(self):
+        """Archives are stamped in UTC, so a TZ change between the pull and
+        the restore must not shift mtimes and defeat the newer-file guard."""
+        self._write("memcards/card.bin", b"archived")
+        archive, _ = broker._build_save_archive(time.time() - 10)
+        original = time.tzset if hasattr(time, "tzset") else None
+        if original is None:
+            self.skipTest("tzset unavailable")
+        __import__("shutil").rmtree(self.memcards)
+        os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14
+        time.tzset()
+        self.addCleanup(lambda: (os.environ.pop("TZ", None), time.tzset()))
+        self.assertEqual(broker._extract_save_archive(archive), (1, 0, 0))
+        stamped = (self.memcards / "card.bin").stat().st_mtime
+        # Within DOS 2 s resolution of when we wrote it, not 14 h away.
+        self.assertLess(abs(stamped - time.time()), 120)
+
+    def test_rejects_path_traversal(self):
+        result = broker._extract_save_archive(self._zip({"../../etc/passwd": b"x"}))
+        self.assertIsInstance(result, str)
+        self.assertIn("escapes save dir", result)
+
+    def test_rejects_members_outside_allowed_subtrees(self):
+        result = broker._extract_save_archive(self._zip({"sstates/evil.p2s": b"x"}))
+        self.assertIsInstance(result, str)
+        self.assertIn("outside save subtrees", result)
+
+    def test_rejects_non_zip_body(self):
+        self.assertIn("not a zip", broker._extract_save_archive(b"garbage"))
+
+    def test_unstable_file_is_skipped_not_shipped_torn(self):
+        self._write("memcards/card.bin", b"x" * 100)
+        with mock.patch.object(broker, "_read_file_stable", return_value=None):
+            result = broker._build_save_archive(time.time() - 10)
+        # Every changed file was mid-write: no archive, caller must refuse.
+        self.assertEqual(result, (None, 1))
+
+
+class MemoryCardTests(_TempRootMixin, unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        ini = self.root / "PCSX2.ini"
+        ini.write_text("[MemoryCards]\nSlot1_Filename = Mcd001\n")
+        patcher = mock.patch.object(broker, "INI_PATH", ini)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.card = self.memcards / "Mcd001"
+
+    def test_reads_slot1_name_from_ini(self):
+        self.assertEqual(broker._slot1_filename(), "Mcd001")
+        self.assertEqual(broker._slot1_card_path(), self.card)
+
+    def test_slot1_name_is_basename_only(self):
+        (self.root / "PCSX2.ini").write_text(
+            "[MemoryCards]\nSlot1_Filename = ../../escape/Mcd001\n"
+        )
+        self.assertEqual(broker._slot1_card_path().parent, self.memcards)
+
+    def test_archive_members_are_relative_to_card_root(self):
+        self._write("memcards/Mcd001/BASLUS-1/save.bin", b"G")
+        self._write("memcards/Mcd001/_pcsx2_superblock", b"S")
+        with zipfile.ZipFile(io.BytesIO(broker._build_memory_card_archive())) as zf:
+            self.assertEqual(
+                sorted(zf.namelist()), ["BASLUS-1/save.bin", "_pcsx2_superblock"]
+            )
+
+    def test_replace_wipes_the_whole_card(self):
+        self._write("memcards/Mcd001/BASLUS-1/old.bin", b"O")
+        self._write("memcards/Mcd001/_pcsx2_superblock", b"S")
+        payload = self._zip({"_pcsx2_superblock": b"T", "BASLUS-2/new.bin": b"N"})
+        self.assertEqual(broker._replace_memory_card(payload), (2,))
+        present = sorted(p.relative_to(self.card).as_posix() for p in self.card.rglob("*"))
+        self.assertEqual(present, ["BASLUS-2", "BASLUS-2/new.bin", "_pcsx2_superblock"])
+
+    def test_replace_leaves_no_staging_or_backup_dirs(self):
+        self._write("memcards/Mcd001/_pcsx2_superblock", b"S")
+        broker._replace_memory_card(self._zip({"_pcsx2_superblock": b"T"}))
+        leftovers = [p.name for p in self.memcards.iterdir() if p.name.startswith(".")]
+        self.assertEqual(leftovers, [])
+
+    def test_rejected_traversal_leaves_card_intact(self):
+        self._write("memcards/Mcd001/_pcsx2_superblock", b"S")
+        result = broker._replace_memory_card(self._zip({"../escape": b"x"}))
+        self.assertIn("escapes card dir", result)
+        self.assertEqual((self.card / "_pcsx2_superblock").read_bytes(), b"S")
+
+    def test_file_card_is_refused_both_directions(self):
+        self.memcards.mkdir(parents=True, exist_ok=True)
+        self.card.write_bytes(b"file card")
+        self.assertIn("File memory card", broker._build_memory_card_archive())
+        self.assertIn("File memory card", broker._replace_memory_card(self._zip({"a": b"b"})))
+
+    def test_absent_card_reports_none_not_error(self):
+        """A missing card must be distinguishable from a broken one — the
+        handler turns None into the tagged 404 the backend keys on."""
+        self.assertIsNone(broker._build_memory_card_archive())
+
+    def test_no_slot_configured_is_an_error_on_replace(self):
+        (self.root / "PCSX2.ini").write_text("[MemoryCards]\n")
+        self.assertIn("no Slot 1", broker._replace_memory_card(self._zip({"a": b"b"})))
+
+
+class IniTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.ini = self.tmp / "PCSX2.ini"
+        patcher = mock.patch.object(broker, "INI_PATH", self.ini)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_patch_overwrites_existing_key_in_correct_section(self):
+        self.ini.write_text("[EmuCore]\nEnablePINE = false\n")
+        broker._patch_ini()
+        self.assertIn("EnablePINE = true", self.ini.read_text())
+
+    def test_patch_does_not_touch_same_key_in_another_section(self):
+        self.ini.write_text("[Other]\nEnablePINE = false\n\n[EmuCore]\nEnablePINE = false\n")
+        broker._patch_ini()
+        other, emucore = self.ini.read_text().split("[EmuCore]")
+        self.assertIn("EnablePINE = false", other)
+        self.assertIn("EnablePINE = true", emucore)
+
+    def test_patch_creates_missing_sections(self):
+        self.ini.write_text("[Unrelated]\nx = 1\n")
+        broker._patch_ini()
+        text = self.ini.read_text()
+        self.assertIn("[UI]", text)
+        self.assertIn("StartFullscreen = true", text)
+        self.assertIn("ConfirmShutdown = false", text)
+
+    def test_patch_is_idempotent(self):
+        self.ini.write_text("[EmuCore]\nEnablePINE = false\n")
+        broker._patch_ini()
+        first = self.ini.read_text()
+        broker._patch_ini()
+        self.assertEqual(first, self.ini.read_text())
+
+    def test_initial_slot_read_from_ini(self):
+        self.ini.write_text("[EmuCore]\nSaveStateSlot = 7\n")
+        self.assertEqual(broker._read_initial_save_slot(), 7)
+
+    def test_initial_slot_falls_back_when_out_of_range(self):
+        self.ini.write_text("[EmuCore]\nSaveStateSlot = 99\n")
+        self.assertEqual(broker._read_initial_save_slot(), 1)
+
+    def test_initial_slot_falls_back_when_absent(self):
+        self.ini.write_text("[EmuCore]\n")
+        self.assertEqual(broker._read_initial_save_slot(), 1)
+
+
+class SlotMatchTests(unittest.TestCase):
+
+    def test_matches_padded_and_bare_slot_suffixes(self):
+        self.assertTrue(broker._matches_slot(Path("SLUS-1 (A).03.p2s"), 3))
+        self.assertTrue(broker._matches_slot(Path("SLUS-1 (A).3.p2s"), 3))
+        self.assertTrue(broker._matches_slot(Path("SLUS-1 (A).10.p2s"), 10))
+
+    def test_does_not_match_other_slots(self):
+        self.assertFalse(broker._matches_slot(Path("SLUS-1 (A).04.p2s"), 3))
+        self.assertFalse(broker._matches_slot(Path("SLUS-1 (A).03.p2s"), 10))
+
+
+class _FakeProc:
+    """Stands in for a pcsx2-qt Popen that has already exited."""
+    pid = 4242
+
+    def wait(self):
+        return 0
+
+    def poll(self):
+        return 0
+
+
+class LifecycleTests(unittest.TestCase):
+
+    def setUp(self):
+        _reset_session()
+        self.addCleanup(_reset_session)
+        self.launched = []
+        self.launch_patcher = mock.patch.object(
+            broker, "_launch_pcsx2_internal", lambda rom: self.launched.append(rom)
+        )
+        self.launch_patcher.start()
+        self.addCleanup(self.launch_patcher.stop)
+        # Collapse the crash-relaunch backoff so tests don't sleep.
+        sleep_patch = mock.patch.object(broker.time, "sleep", lambda _s: None)
+        sleep_patch.start()
+        self.addCleanup(sleep_patch.stop)
+        self.proc = _FakeProc()
+
+    def _crash(self, ran_for=60.0):
+        broker._session.update({"process": self.proc, "is_managed": True})
+        broker._monitor_process(self.proc, time.monotonic() - ran_for)
+
+    def test_unexpected_exit_relaunches_dashboard(self):
+        broker._session["rom_path"] = "/romm/library/ps2/game.chd"
+        self._crash()
+        self.assertEqual(self.launched, [None])
+        self.assertIsNone(broker._session["rom_path"])
+        self.assertEqual(broker._session["rom_name"], "Dashboard")
+
+    def test_deliberate_kill_does_not_relaunch(self):
+        broker._session.update({"process": None, "is_managed": False})
+        broker._monitor_process(self.proc, time.monotonic() - 60)
+        self.assertEqual(self.launched, [])
+
+    def test_crash_loop_gives_up_and_flags_status(self):
+        for _ in range(broker._CRASH_LOOP_LIMIT + 1):
+            broker._session["launch_in_progress"] = False
+            self._crash(ran_for=0.5)
+        self.assertEqual(len(self.launched), broker._CRASH_LOOP_LIMIT - 1)
+        self.assertTrue(broker._session["relaunch_abandoned"])
+
+    def test_deliberate_kills_do_not_count_toward_crash_loop(self):
+        for _ in range(5):
+            broker._session.update({"process": None, "is_managed": False})
+            broker._monitor_process(self.proc, time.monotonic() - 0.5)
+        self.assertEqual(broker._rapid_exits, 0)
+
+    def test_long_run_resets_the_crash_counter(self):
+        self._crash(ran_for=0.5)
+        broker._session["launch_in_progress"] = False
+        self._crash(ran_for=600)
+        self.assertEqual(broker._rapid_exits, 0)
+
+    def test_crash_relaunch_skipped_while_a_launch_holds_the_claim(self):
+        self.assertTrue(broker._claim_launch())
+        self._crash()
+        self.assertEqual(self.launched, [])
+
+    def test_card_hydrate_does_not_block_crash_recovery(self):
+        """Regression: the card op used to borrow launch_in_progress, so a
+        crash during a hydrate left no emulator running and nothing retried."""
+        self.assertTrue(broker._claim_card_op())
+        self._crash()
+        self.assertEqual(self.launched, [None])
+
+    def test_card_op_refused_while_a_game_is_running(self):
+        broker._session["rom_path"] = "/romm/library/ps2/game.chd"
+        self.assertFalse(broker._claim_card_op())
+
+    def test_card_op_refused_while_a_launch_is_in_flight(self):
+        self.assertTrue(broker._claim_launch())
+        self.assertFalse(broker._claim_card_op())
+
+    def test_card_op_is_exclusive(self):
+        self.assertTrue(broker._claim_card_op())
+        self.assertFalse(broker._claim_card_op())
+        broker._release_card_op()
+        self.assertTrue(broker._claim_card_op())
+
+    def test_launch_claim_is_exclusive(self):
+        self.assertTrue(broker._claim_launch())
+        self.assertFalse(broker._claim_launch())
+
+    def test_successful_launch_clears_the_abandoned_flag(self):
+        """Once an instance is up again, the limiter's verdict is stale and
+        /status must stop reporting the container as surrendered."""
+        broker._session["relaunch_abandoned"] = True
+        self.addCleanup(self.launch_patcher.start)
+        self.launch_patcher.stop()  # exercise the real _launch_pcsx2_internal
+        log_path = Path(tempfile.mkdtemp()) / "pcsx2-qt.log"
+        with mock.patch.object(broker, "PCSX2_LOG_PATH", log_path), \
+             mock.patch.object(broker.subprocess, "Popen", return_value=self.proc), \
+             mock.patch.object(broker, "_read_initial_save_slot", return_value=1), \
+             mock.patch.object(broker, "Thread") as thread:
+            thread.return_value.start.return_value = None
+            broker._launch_pcsx2_internal(None)
+        self.assertFalse(broker._session["relaunch_abandoned"])
+        self.assertIs(broker._session["process"], self.proc)
+        self.assertTrue(broker._session["is_managed"])
+
+
+class DeferredLoadTests(unittest.TestCase):
+
+    def setUp(self):
+        _reset_session()
+        self.addCleanup(_reset_session)
+        sleep_patch = mock.patch.object(broker.time, "sleep", lambda _s: None)
+        sleep_patch.start()
+        self.addCleanup(sleep_patch.stop)
+
+    def test_abandons_when_a_newer_launch_supersedes_it(self):
+        broker._session["launch_seq"] = 5
+        with mock.patch.object(broker, "_load_state") as load:
+            broker._deferred_load_state(3, seq=4)  # stale generation
+        load.assert_not_called()
+
+    def test_loads_when_generation_still_matches(self):
+        broker._session["launch_seq"] = 4
+        with mock.patch.object(broker, "_pine_emu_status", return_value=0), \
+             mock.patch.object(broker, "_load_state", return_value=True) as load:
+            broker._deferred_load_state(3, seq=4)
+        load.assert_called_once_with(3)
+
+    def test_gives_up_when_vm_never_reaches_running(self):
+        broker._session["launch_seq"] = 1
+        with mock.patch.object(broker, "RESUME_LOAD_WAIT", 0.01), \
+             mock.patch.object(broker, "_pine_emu_status", return_value=2), \
+             mock.patch.object(broker, "_load_state") as load:
+            broker._deferred_load_state(3, seq=1)
+        load.assert_not_called()
+
+
+class RomPathValidationTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp()).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        patcher = mock.patch.object(broker, "ROM_ROOT", self.tmp)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_accepts_path_under_rom_root(self):
+        p = self.tmp / "ps2" / "game.chd"
+        self.assertEqual(broker._validate_rom_path(str(p)), p)
+
+    def test_rejects_path_outside_rom_root(self):
+        self.assertIsNone(broker._validate_rom_path("/etc/passwd"))
+
+    def test_rejects_traversal_escape(self):
+        self.assertIsNone(
+            broker._validate_rom_path(str(self.tmp / ".." / "escape.chd"))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Brings the `dev` line to `main`: RomM save synchronisation for PCSX2 (save states, in-game saves, and whole memory cards), resume-from-state on launch, and a substantial stability pass over the broker's lifecycle and I/O paths.

**Merge with a merge commit, not a squash** — Semantic Release reads individual commit messages on push to `main`, and squashing would collapse the `feat:` commits into one and lose the version bump they imply.

## Features

- **`GET`/`PUT` `/state-file`** — save-state sync with RomM, delivered over PINE IPC (opcodes `0x09`/`0x0A`/`0x0F`) with an xdotool F-key fallback.
- **`GET`/`PUT` `/save-file`** — in-game save sync as a zip archive, delta-based: returns 404 when nothing has changed since launch.
- **`GET`/`PUT` `/memory-card`** — whole-card sync via an atomic staging-directory swap, so a crash mid-hydrate leaves either the old card or the new one, never a partial.
- **`load_slot` on `POST /launch`** — resume straight into a save state, with the load deferred until the VM is up.
- **`patches.zip` fetch** — Ubuntu's `+dfsg` package strips it, so every boot warned and patch-dependent titles misbehaved.
- **`libshaderc1` install** — absent from the base image, so on a GPU host the Vulkan GS renderer failed shader compilation and `pcsx2-qt` exited within a second of booting any game. The gameless dashboard never initialises GS, which masked the breakage until a game was launched.

## Stability

The broker runs under `ThreadingHTTPServer`, so most of this is concurrency correctness:

- `start_new_session=True` replaces `preexec_fn=os.setpgrp`, which is unsafe in a threaded process and can deadlock the child between fork and exec.
- Every kill+relaunch path now holds a single `launch_in_progress` claim. `DELETE /launch`, save-and-exit relaunches, and the monitor's crash relaunch previously ran unclaimed, so two lifecycle sequences could interleave and leave two `pcsx2-qt` instances running.
- The monitor re-checks process identity after its backoff sleep, not just `is_managed` — a launch completing during that sleep used to get its session state stomped with `Dashboard` and a second instance started on top of it.
- A `launch_seq` generation counter aborts a deferred `load_slot` load if another launch superseded it during the 90s wait.
- A crash-loop limiter stops relaunching after 3 consecutive sub-5s exits instead of respawning a broken emulator forever. Deliberate kills don't count toward it, an explicit launch resets it, and the give-up state is exposed as `relaunch_abandoned` on `/status` so a pooled fleet can tell an idle dashboard from a container needing intervention.
- The memory-card replace takes its own claim rather than borrowing `launch_in_progress`. Borrowing it made the crash relaunch skip and never retry, leaving no emulator running at all if `pcsx2-qt` died mid-hydrate.
- Save-state write detection is filtered by target slot; any `.p2s` write used to confirm the save, so an unrelated write reported success for a state that was never written.
- Zip mtimes are stamped and read in UTC. Local time meant a timezone difference between pull and restore silently defeated the last-write-wins guard.
- Save restore continues past per-file failures instead of aborting midway with files already replaced, and reports written/skipped/failed.
- Size limits are enforced by `stat` before read, so an oversized file is refused without being held in memory; truncated request bodies are rejected; `GET /state-file` returns 503 while a save is in flight rather than serving a half-written file.
- Container init skips display-socket cleanup when a display server is already running, and bounds the `patches.zip` fetch so an unresponsive GitHub can't stall startup for an optional file.

## Tests

`tests/test_broker.py` — 47 tests on stdlib `unittest`, no dependencies (the container has no pip). Development-only: the Dockerfile is `FROM scratch` and copies only `root/`, so `tests/` cannot reach the image; `.dockerignore` keeps it out of the build context as well.

```
python3 -m unittest discover -s tests -v
```

## Test Plan

Verified live against the `dev` image on the `nuc-emulators` host, not just in unit tests:

- [x] 47/47 unit tests pass; `broker.py` compiles; `init.sh` passes `bash -n`
- [x] **Concurrent launch race** — two simultaneous `POST /launch` calls: one won, the other was cleanly refused, exactly one `pcsx2-qt` process, `/status` matching the process actually running
- [x] **`PUT /memory-card` refused while a game is running** — 409
- [x] **Memory-card round trip ×2** — pulled the live card (34 entries), pushed it back twice; content byte-identical each time (md5 of the tree unchanged), idempotent
- [x] **Crash-loop limiter** — forced rapid unexpected exits: tripped after 3, set `relaunch_abandoned: true`, `active: false`, and stopped respawning
- [x] **Recovery from the abandoned state** — `POST /launch` cleared the flag and ran a real game normally
- [x] **`DELETE /launch` teardown** — returned to Dashboard cleanly every time, never left an orphan process
- [x] Memory card verified unchanged after all testing; a dated backup was taken first

Pre-existing behaviour noted during testing, neither introduced by this branch and neither blocking:

- An unbootable ROM does not crash PCSX2 — it stays alive on an error dialog, so the broker reports a healthy session for what is actually a dead end.

