### PR TITLE
fix: boot the disc image inside a folder-organized ROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ Kills any running game and launches a new ROM. Returns immediately; launch runs 
 ```
 
 - `rom_path` must exist and be under `ROM_ROOT`
+- `rom_path` may be a **directory**, for libraries laid out one game per folder (`roms/ps2/Jak 3/Jak 3.iso`). RomM addresses such a game by its folder, so the broker looks inside for the disc image: the folder itself first, then one level down for per-disc subfolders. Candidates are ranked by format (`.chd`, `.iso`, `.cso`, `.zso`, `.gz`, `.mdf`, `.dump`, `.bin`, `.elf`) and then by name, so a multi-disc set boots disc 1. Dot-files are skipped, and a symlink pointing outside `ROM_ROOT` is never chosen. The resolved file is what `/status` and the response body report.
 - `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
 - Returns `409` if a save is in progress, a launch is already in progress, or a `/memory-card` replace is in flight
 - Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10
-- Returns `422` if `rom_path` does not exist
+- Returns `422` if `rom_path` does not exist, or if it is a directory with no bootable file inside. The second case reports the accepted extensions in an `extensions` field, so callers never need their own copy of the list
 
 ```json
 { "status": "launching", "rom_path": "/romm/library/ps2/game.chd" }

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import time
 import zipfile
+from collections.abc import Iterable
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path, PurePosixPath
 from threading import Thread, Lock
@@ -191,6 +192,74 @@ def _validate_rom_path(raw: str) -> Path | None:
     if not p.is_relative_to(ROM_ROOT):
         return None
     return p
+
+
+# Disc formats pcsx2-qt can boot, best first: a folder holding several
+# candidates picks by this order, so a .chd beats the raw .bin beside it.
+# .cue is deliberately absent, because pcsx2-qt boots the image itself and
+# every folder shipping a .cue also ships the track it points at.
+ROM_EXTENSIONS = (
+    ".chd", ".iso", ".cso", ".zso", ".gz", ".mdf", ".dump", ".bin", ".elf",
+)
+
+# Where to look for the disc image below a game folder. The folder itself
+# first, then one level down for the per-disc subfolders some sets use
+# (Game/Disc 1/game.iso). Nothing deeper: a launch must not pay for a full
+# walk of a large set, and anything further down is extras, not the game.
+_ROM_SEARCH_GLOBS = ("*", "*/*")
+
+
+def _resolve_rom_file(path: Path) -> Path | None:
+    """Return the file pcsx2-qt should boot for `path`, or None if there
+    isn't one.
+
+    RomM addresses a folder-organized game by its folder: `Rom.full_path` is
+    `fs_path/fs_name`, and for a multi-file ROM `fs_name` is the directory,
+    not the disc image inside it. So /launch regularly receives something
+    like `.../roms/ps2/Jak 3` for a library laid out one game per folder.
+    A path that is already a file passes straight through.
+    """
+    if path.is_file():
+        return path
+    if not path.is_dir():
+        return None
+    for pattern in _ROM_SEARCH_GLOBS:
+        try:
+            found = _pick_rom_file(path.glob(pattern))
+        except OSError:
+            # Libraries are routinely NFS mounts, so a stalled or vanished
+            # share surfaces here as an OSError mid-walk. Report it as "no
+            # bootable file" rather than 500-ing the launch.
+            return None
+        if found is not None:
+            return found
+    return None
+
+
+def _pick_rom_file(candidates: Iterable[Path]) -> Path | None:
+    """Best bootable file among `candidates`, by format preference then name
+    (which puts 'Disc 1' ahead of 'Disc 2' for a multi-disc set)."""
+    ranked: list[tuple[int, str, Path]] = []
+    for p in candidates:
+        if p.name.startswith("."):
+            continue
+        ext = p.suffix.lower()
+        if ext not in ROM_EXTENSIONS:
+            continue
+        try:
+            if not p.is_file():
+                continue
+            # A symlink in the folder must not walk the launch out of
+            # ROM_ROOT: _validate_rom_path only vetted the folder itself.
+            real = p.resolve()
+        except OSError:
+            continue
+        if not real.is_relative_to(ROM_ROOT):
+            continue
+        ranked.append((ROM_EXTENSIONS.index(ext), p.name.lower(), real))
+    if not ranked:
+        return None
+    return min(ranked)[2]
 
 
 def _patch_ini():
@@ -2043,6 +2112,20 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if not rom_path.exists():
             self._send_json(422, {"error": "rom_path does not exist", "path": str(rom_path)})
             return
+
+        # A folder-organized game arrives as its folder, which pcsx2-qt cannot
+        # boot; find the disc image inside it.
+        rom_file = _resolve_rom_file(rom_path)
+        if rom_file is None:
+            self._send_json(422, {
+                "error": "no bootable ROM file found under rom_path",
+                "path": str(rom_path),
+                "extensions": list(ROM_EXTENSIONS),
+            })
+            return
+        if rom_file != rom_path:
+            log.info("Resolved ROM folder %s to %s", rom_path, rom_file)
+        rom_path = rom_file
 
         # Resume-from-state: load this slot once the game VM is up.
         load_slot = body.get("load_slot")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -438,7 +438,8 @@ class DeferredLoadTests(unittest.TestCase):
         load.assert_not_called()
 
 
-class RomPathValidationTests(unittest.TestCase):
+class _RomRootMixin:
+    """Gives each test an isolated ROM_ROOT to build library layouts in."""
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp()).resolve()
@@ -446,6 +447,15 @@ class RomPathValidationTests(unittest.TestCase):
         patcher = mock.patch.object(broker, "ROM_ROOT", self.tmp)
         patcher.start()
         self.addCleanup(patcher.stop)
+
+    def _rom(self, rel, data=b"disc"):
+        p = self.tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+        return p
+
+
+class RomPathValidationTests(_RomRootMixin, unittest.TestCase):
 
     def test_accepts_path_under_rom_root(self):
         p = self.tmp / "ps2" / "game.chd"
@@ -458,6 +468,124 @@ class RomPathValidationTests(unittest.TestCase):
         self.assertIsNone(
             broker._validate_rom_path(str(self.tmp / ".." / "escape.chd"))
         )
+
+
+class RomFileResolutionTests(_RomRootMixin, unittest.TestCase):
+    """Issue #11: RomM addresses a folder-organized game by its folder, so
+    /launch receives a directory pcsx2-qt cannot boot."""
+
+    def test_plain_file_passes_through(self):
+        iso = self._rom("ps2/game.iso")
+        self.assertEqual(broker._resolve_rom_file(iso), iso)
+
+    def test_game_folder_resolves_to_the_disc_image_inside(self):
+        iso = self._rom("ps2/Jak 3/Jak 3.iso")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "Jak 3"), iso)
+
+    def test_folder_without_a_bootable_file_returns_none(self):
+        self._rom("ps2/Jak 3/cover.jpg")
+        self._rom("ps2/Jak 3/notes.txt")
+        self.assertIsNone(broker._resolve_rom_file(self.tmp / "ps2" / "Jak 3"))
+
+    def test_multi_disc_folder_picks_disc_one(self):
+        disc1 = self._rom("ps2/FFX/FFX (Disc 1).iso")
+        self._rom("ps2/FFX/FFX (Disc 2).iso")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "FFX"), disc1)
+
+    def test_better_format_wins_over_a_raw_track(self):
+        chd = self._rom("ps2/Game/Game.chd")
+        self._rom("ps2/Game/Game (Track 1).bin")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "Game"), chd)
+
+    def test_cue_sheet_is_not_chosen_over_its_image(self):
+        binf = self._rom("ps2/Game/Game.bin")
+        self._rom("ps2/Game/Game.cue")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "Game"), binf)
+
+    def test_finds_image_in_a_per_disc_subfolder(self):
+        disc1 = self._rom("ps2/FFX/Disc 1/FFX.iso")
+        self._rom("ps2/FFX/Disc 2/FFX.iso")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "FFX"), disc1)
+
+    def test_top_level_image_wins_over_a_nested_one(self):
+        top = self._rom("ps2/Game/Game.iso")
+        self._rom("ps2/Game/extras/bonus.iso")
+        self.assertEqual(broker._resolve_rom_file(self.tmp / "ps2" / "Game"), top)
+
+    def test_does_not_descend_past_the_second_level(self):
+        self._rom("ps2/Game/a/b/deep.iso")
+        self.assertIsNone(broker._resolve_rom_file(self.tmp / "ps2" / "Game"))
+
+    def test_hidden_files_are_ignored(self):
+        self._rom("ps2/Game/._Game.iso")
+        self.assertIsNone(broker._resolve_rom_file(self.tmp / "ps2" / "Game"))
+
+    def test_symlink_escaping_rom_root_is_refused(self):
+        outside = Path(tempfile.mkdtemp()).resolve() / "escape.iso"
+        self.addCleanup(
+            lambda: __import__("shutil").rmtree(outside.parent, ignore_errors=True)
+        )
+        outside.write_bytes(b"disc")
+        folder = self.tmp / "ps2" / "Game"
+        folder.mkdir(parents=True)
+        (folder / "link.iso").symlink_to(outside)
+        self.assertIsNone(broker._resolve_rom_file(folder))
+
+    def test_missing_path_returns_none(self):
+        self.assertIsNone(broker._resolve_rom_file(self.tmp / "ps2" / "nope"))
+
+
+class _FakeHandler(broker.BrokerHandler):
+    """Drives do_POST without a socket: the request line and body are given
+    up front and the response is captured instead of written."""
+
+    def __init__(self, path, body):
+        self.path = path
+        self._body = body
+        self.sent = None
+
+    def _check_secret(self):
+        return True
+
+    def _read_body(self):
+        return self._body
+
+    def _send_json(self, code, body, headers=None):
+        self.sent = (code, body)
+
+
+class LaunchEndpointTests(_RomRootMixin, unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        _reset_session()
+        self.addCleanup(_reset_session)
+
+    def _post_launch(self, rom_path):
+        handler = _FakeHandler("/launch", {"rom_path": str(rom_path)})
+        with mock.patch.object(broker, "Thread") as thread:
+            handler.do_POST()
+        self.thread = thread
+        return handler.sent
+
+    def test_launching_a_game_folder_boots_the_file_inside(self):
+        iso = self._rom("ps2/Jak 3/Jak 3.iso")
+        code, body = self._post_launch(self.tmp / "ps2" / "Jak 3")
+        self.assertEqual(code, 200)
+        self.assertEqual(body["rom_path"], str(iso))
+        self.assertEqual(self.thread.call_args.kwargs["args"][0], str(iso))
+
+    def test_folder_without_a_bootable_file_is_reported_distinctly(self):
+        self._rom("ps2/Jak 3/cover.jpg")
+        code, body = self._post_launch(self.tmp / "ps2" / "Jak 3")
+        self.assertEqual(code, 422)
+        self.assertIn("no bootable ROM file", body["error"])
+        self.assertFalse(broker._session["launch_in_progress"])
+
+    def test_missing_path_still_reports_that_it_does_not_exist(self):
+        code, body = self._post_launch(self.tmp / "ps2" / "nope")
+        self.assertEqual(code, 422)
+        self.assertEqual(body["error"], "rom_path does not exist")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #11.

## The bug

RomM addresses a multi-file ROM by its folder. `Rom.full_path` is `fs_path/fs_name`, and for a folder-organized game `fs_name` is the directory, not the image inside it, so `POST /launch` receives `.../roms/ps2/Jak 3` and the broker hands `pcsx2-qt` a directory it cannot boot. One-game-per-folder libraries are common (Redump sets ship that way), and this affects every platform, not just PS2.

## The fix

`_resolve_rom_file()` resolves a directory to the file to boot before launching:

- Searches the folder itself first, then one level down for the per-disc subfolders some sets use. Nothing deeper, so a launch never pays for a full walk of a large set.
- Ranks candidates by format (`ROM_EXTENSIONS`, best first) and then by name, so a multi-disc set boots disc 1 and a `.chd` wins over the raw `.bin` beside it. `.cue` is not a candidate: `pcsx2-qt` boots the image itself, and any folder shipping a `.cue` also ships the track it points at.
- Re-resolves each candidate and re-checks it against `ROM_ROOT`. `_validate_rom_path` only vetted the folder, so without this a symlink inside it could walk the launch out of the library.

A folder with nothing bootable now returns its own 422 instead of the "does not exist" one, and reports the accepted extensions so callers do not need their own copy of the list.

## Tests

15 new tests. `RomFileResolutionTests` covers the issue's exact layout, multi-disc disc-1 preference, format ranking, cue-vs-image, per-disc subfolders, top-level winning over nested, the depth cap, dot-files, symlink escape, and missing paths. `LaunchEndpointTests` drives the real `do_POST` through a socket-free handler, and its folder case failed on the pre-fix code by launching the directory. The duplicated `ROM_ROOT` fixture in `RomPathValidationTests` moved into a shared mixin.

62/62 pass (`pytest` and `python3 -m unittest discover -s tests`).

## Note for triage

The reporter's 422 was `rom_path does not exist`, which the broker only returns when it cannot stat the path at all. An existing directory always passed that check and failed later inside PCSX2. So if they still see that error after this lands, the PCSX2 container cannot see the folder and it is a mount problem rather than a lookup one. The two failures are now distinguishable from the response alone.
