### PR TITLE
chore(ci): gate publishes on ci-test and correct the README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  ci-test:
+    uses: ./.github/workflows/ci.yml
+
   release:
+    needs: ci-test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI Test Suite
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # The job id IS the status-check context named by the branch ruleset.
+  # Do not add a `name:` key here - it would rename the reported check and
+  # the required-check rule would block every PR waiting on "ci-test".
+  ci-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          # No `cache: pip` on purpose: setup-python hard-fails when no
+          # requirements.txt/pyproject.toml exists, and these repos have none.
+
+      - name: Install tooling
+        run: pip install pytest==8.3.4 ruff==0.15.22
+
+      - name: Run linter (ruff)
+        run: ruff check .
+
+      - name: Run unit tests (pytest)
+        run: |
+          if ls tests/test_*.py >/dev/null 2>&1; then
+            pytest tests/ -q
+          else
+            echo "::notice::no tests/ in this repo yet - ci-test is a lint-only gate"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   # The job id IS the status-check context named by the branch ruleset.
-  # Do not add a `name:` key here - it would rename the reported check and
+  # Do not add a `name:` key here: it would rename the reported check and
   # the required-check rule would block every PR waiting on "ci-test".
   ci-test:
     runs-on: ubuntu-latest
@@ -34,9 +34,17 @@ jobs:
         run: ruff check .
 
       - name: Run unit tests (pytest)
+        env:
+          # Flip to 'true' once this repo has a suite. Without it a deleted or
+          # unstaged tests/ directory silently downgrades ci-test to a lint-only
+          # gate and still reports green, which is the failure mode this guards.
+          EXPECT_TESTS: 'true'
         run: |
           if ls tests/test_*.py >/dev/null 2>&1; then
             pytest tests/ -q
+          elif [ "$EXPECT_TESTS" = "true" ]; then
+            echo "::error::EXPECT_TESTS is set but no tests/test_*.py were found"
+            exit 1
           else
-            echo "::notice::no tests/ in this repo yet - ci-test is a lint-only gate"
+            echo "::notice::no tests/ in this repo yet, ci-test is a lint-only gate"
           fi

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  ci-test:
+    uses: ./.github/workflows/ci.yml
+
   docker:
+    needs: ci-test
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This mod installs a small HTTP broker inside the [linuxserver/pcsx2](https://doc
 
 1. Exposes an API on port 8000 so RomM can request game launches
 2. Manages the PCSX2 process lifecycle (start, stop, game switching, dashboard mode)
-3. Saves game state by sending an F-key to the PCSX2 window (via xdotool) before exit
-4. Patches Selkies and PCSX2 at init time for reliable controller and socket handling
+3. Saves/loads game state via PCSX2's native PINE IPC socket, falling back to xdotool F-key delivery if PINE is unreachable
+4. Patches Selkies at container init, and PCSX2.ini before every launch, for reliable controller and PINE/save-state handling
 5. Supervises itself via s6-overlay (auto-restarts on crash)
 
 ---
@@ -89,16 +89,17 @@ Slot1_Filename = my-folder-card.ps2   # this is a directory on disk, not a file
 | `BROKER_SECRET` | *(none)* | Shared secret for authentication. Sent as the `X-Broker-Secret` header. If unset, all requests are accepted — not recommended on a shared network. |
 | `BROKER_PORT` | `8000` | Port the broker HTTP server listens on. |
 | `ROM_ROOT` | `/romm/library` | Root path inside the container where ROMs are mounted. Requests with a `rom_path` outside this directory are rejected. |
-| `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after sending the save keypress. Polling stops early once the write is detected. Increase for slow disks or large games. (Name kept for backwards compatibility — the broker now confirms writes for the xdotool save path, not PINE.) |
+| `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after a save is accepted, whether the save was delivered via PINE (PCSX2's native IPC socket, tried first) or the xdotool F-key fallback. Polling stops early once the write is detected. Increase for slow disks or large games. |
 | `SAVE_SLOT` | `10` | Default save state slot (1–10) for `/save-and-exit` when no `slot` is specified. Slot 10 is recommended as an auto-save slot, leaving 1–9 free for manual use. |
 | `SSTATE_DIR` | `/config/.config/PCSX2/sstates` | Where PCSX2 writes save state files. Served and written by the `/state-file` endpoints for RomM's save-state sync. |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish before serving the slot file. |
 | `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game VM to reach running state before giving up on the deferred state load. |
 | `RESUME_LOAD_SETTLE` | `3.0` | Seconds to let the game settle after the VM reports running, before the deferred `load_slot` state load fires. |
 | `SAVE_DATA_ROOT` | `/config/.config/PCSX2` | Override for the PCSX2 data dir the `/save-file` and `/memory-card` endpoints operate on. Only the `memcards/` subtree under it is synced. |
-| `BROKER_INITIAL_SLOT` | `1` | Fallback save state slot the broker assumes PCSX2 starts on when `SaveStateSlot` can't be read from `PCSX2.ini`. Only affects xdotool slot cycling. |
+| `BROKER_INITIAL_SLOT` | `1` | Fallback save state slot the broker assumes PCSX2 starts on when `SaveStateSlot` can't be read from `PCSX2.ini`. Only affects xdotool slot cycling — PINE saves/loads carry the target slot directly and don't need it. |
 | `PCSX2_LOG_PATH` | `/config/pcsx2-qt.log` | File that captures pcsx2-qt's stdout/stderr (renderer, Vulkan, Qt errors). Appended across launches. |
-| `BROKER_LOG_LEVEL` | `INFO` | Broker log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `BROKER_LOG_LEVEL` | `INFO` | Broker log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Note: the xdotool window-search success logs (`xdotool: found window ...`) are DEBUG-level; set `BROKER_LOG_LEVEL=DEBUG` to see them. |
+| `PUID` / `PGID` | `1000` / `1000` | Standard LinuxServer container UID/GID. The broker also uses these directly to `chown` files it writes on PCSX2's behalf — `pcsx2-qt.log`, pulled save-state files, and restored save/memory-card files — so pcsx2-qt (running as `abc`) can read and overwrite them later. |
 
 ---
 
@@ -122,7 +123,9 @@ The `platform` value must match the platform slug used for your PS2 ROMs in RomM
 
 ## API Reference
 
-All endpoints return JSON. If `BROKER_SECRET` is configured, include `X-Broker-Secret: <secret>` in every request.
+All endpoints return JSON except the raw-bytes/zip bodies noted below. If `BROKER_SECRET` is configured, include `X-Broker-Secret: <secret>` in every request; a missing or wrong secret returns `403 {"error": "forbidden"}`. `GET /health` is the one exception — it never checks the secret, so it can be used as an unauthenticated container healthcheck.
+
+JSON request bodies over 64 KB are rejected with `413`; a body that isn't valid JSON, or isn't a JSON object, is rejected with `400`. This applies to every `POST` endpoint below that takes a body (`/launch`, `/save-and-exit`, `/volume`, `/mute`, `/save-state`, `/load-state`).
 
 ---
 
@@ -150,9 +153,11 @@ Returns the current session.
 }
 ```
 
-Returns `{"active": false, ...}` when no game is running.
+`active` reflects whether a pcsx2-qt process is alive at all — **the idle dashboard counts as active too.** It is not "a game is running"; use `rom_path` for that (non-null only when an actual ROM is loaded, `null` for the dashboard). `rom_name` and `started_at` are `null` unless a game is loaded, and all three of `rom_path`/`rom_name`/`started_at` are forced to `null` in the response whenever `active` is `false`, regardless of what the broker still has cached internally.
 
-`relaunch_abandoned` is `true` once PCSX2 has exited within 5 s three times in a row and the broker has stopped restarting it — nothing is running and nothing will recover it without an explicit `POST /launch`. Monitor this to tell a container that is idle at the dashboard (`active: false`, `relaunch_abandoned: false`) from one that has given up (`active: false`, `relaunch_abandoned: true`); the latter needs intervention, usually a GPU/renderer failure visible in `PCSX2_LOG_PATH`.
+`active` is `false` only briefly during a kill-then-relaunch sequence, or persistently once the crash-loop limiter has given up.
+
+`relaunch_abandoned` is `true` once PCSX2 has exited within 5 s three times in a row and the broker has stopped restarting it — nothing is running and nothing will recover it without an explicit `POST /launch`. Monitor this to tell a container idle at the dashboard (`active: true`, `rom_path: null`, `relaunch_abandoned: false`) from one that has given up (`active: false`, `relaunch_abandoned: true`); the latter needs intervention, usually a GPU/renderer failure visible in `PCSX2_LOG_PATH`.
 
 ---
 
@@ -161,10 +166,10 @@ Returns `{"active": false, ...}` when no game is running.
 Kills any running game and launches a new ROM. Returns immediately; launch runs in a background thread.
 
 ```json
-{ "rom_path": "/romm/library/ps2/game.chd", "rom_name": "Game Title", "load_slot": 3 }
+{ "rom_path": "/romm/library/ps2/game.chd", "load_slot": 3 }
 ```
 
-- `rom_path` must exist and be under `ROM_ROOT`
+- `rom_path` must exist and be under `ROM_ROOT`. `rom_name` (as shown in `/status`) is not read from the request — it is always derived from `rom_path`'s filename stem.
 - `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
 - Returns `409` if a save is in progress, a launch is already in progress, or a `/memory-card` replace is in flight
 - Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10
@@ -190,7 +195,7 @@ Stops the current game and returns PCSX2 to dashboard mode. Runs in background.
 
 ### `POST /save-and-exit`
 
-Saves the current game state via xdotool F-key, kills PCSX2, then relaunches the dashboard.
+Saves the current game state via PINE (PCSX2's native IPC socket; falls back to an xdotool F-key press if PINE is unreachable), kills PCSX2, then relaunches the dashboard.
 
 Save states are written to `SSTATE_DIR` as `{SERIAL} ({CRC}).{slot:02d}.p2s`.
 
@@ -221,7 +226,7 @@ Save states are written to `SSTATE_DIR` as `{SERIAL} ({CRC}).{slot:02d}.p2s`.
 
 ### `POST /save-state`
 
-Saves the current game to a slot without exiting. The keypress goes to the PCSX2 window via xdotool and the save runs in the background, so a `200` means the keystroke was sent — not that the write finished. Watch `/status` (`save_in_progress`) to confirm.
+Saves the current game to a slot without exiting, via PINE (falling back to an xdotool F-key press if PINE is unreachable). The save runs in the background, so a `200` means the save was dispatched — not that the write finished. `/status` does not expose a `save_in_progress` field; to confirm the write completed, `GET /state-file` for the same slot — it blocks until any in-flight save finishes (up to `STATE_GET_WAIT`) rather than serving a stale or half-written file. A second `/save-state` call while one is still running gets `409`.
 
 ```json
 { "slot": 1 }
@@ -242,7 +247,7 @@ Saves the current game to a slot without exiting. The keypress goes to the PCSX2
 
 ### `POST /load-state`
 
-Loads a save state into the running game. This one blocks until the keystroke is dispatched.
+Loads a save state into the running game via PINE (falling back to xdotool F-key delivery if PINE is unreachable). This one blocks until the load is dispatched.
 
 ```json
 { "slot": 1 }
@@ -258,7 +263,7 @@ Loads a save state into the running game. This one blocks until the keystroke is
 
 - Returns `409` if no game is running
 - Returns `400` if `slot` is not an integer 1–10
-- Returns `503` if the PCSX2 window can't be reached (the broker itself is fine)
+- Returns `503` if the load could not be delivered over PINE or xdotool (the broker itself is fine)
 
 ---
 
@@ -275,6 +280,7 @@ Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centra
 - Returns `400` if `slot` is not an integer 0–10
 - Returns `503` if a save is still in flight after `STATE_GET_WAIT` — retry rather than accept a half-written file
 - Returns `413` if the state file exceeds 256 MB
+- Returns `500` if the state file can't be read (filesystem error)
 
 ---
 
@@ -283,12 +289,16 @@ Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centra
 Writes a state file into the sstates directory, used by RomM to hydrate a freshly claimed container with the user's stored states. `NAME` is the filename a previous GET returned — written back verbatim so PCSX2 recognises the slot.
 
 - Body is the raw file content (`Content-Length` required, max 256 MB)
-- `NAME` must be a bare `.p2s` basename; path components are rejected
+- `NAME` must be a bare `.p2s` basename that doesn't start with a dot; path components are rejected
 - The write is atomic (temp file + rename) and the file is chowned to `abc` so PCSX2 can overwrite the slot later
 
 ```json
 { "status": "ok", "filename": "SLUS-12345 (ABCD1234).03.p2s" }
 ```
+
+- Returns `400` if `filename` is missing, hidden, not a `.p2s` basename, or `Content-Length` is missing/invalid or the body is truncated
+- Returns `413` if the body exceeds 256 MB
+- Returns `500` if the write fails (filesystem error)
 
 ---
 
@@ -298,7 +308,8 @@ Zips every in-game save (memory-card file under `memcards/`) modified since the 
 
 - Response body is `application/zip`; a suggested name is echoed in `X-Save-Filename`
 - Files still being written are skipped; their count is reported in `X-Save-Skipped-Unstable`
-- Returns `404` if no game has been launched, or nothing changed since the last launch
+- Returns `404 {"error": "no game has been launched"}` if the broker has never launched a ROM this session
+- Returns `404 {"error": "no save changes since last launch"}` when nothing under `memcards/` changed since the last game launch — this is the expected steady-state response between saves, not a failure; poll again after the player actually saves
 - Returns `413` if the changed set exceeds 256 MB
 - Returns `503` if every changed file was mid-write — retry shortly
 
@@ -310,7 +321,8 @@ Restores a previously pulled save archive into the data dir, used to hydrate a c
 
 - Body is the raw zip (`Content-Length` required, max 256 MB)
 - Archive members must live under `memcards/`; anything else is rejected
-- Returns `400` for a bad/truncated archive or a member outside the allowed subtree
+- Returns `400` for a missing/empty/truncated body, a bad archive, or a member outside the allowed subtree
+- Returns `413` if the body exceeds 256 MB
 - Returns `500` if some members could not be written — the response carries `written`/`skipped`/`failed` counts, and retrying the same archive is safe (idempotent)
 
 ```json
@@ -337,7 +349,8 @@ Wipes the Slot-1 folder card and lays down the pulled card image (no per-file me
 - Refused while a game is running or a launch is in flight — PCSX2 holds the card open and replacing it mid-game corrupts it. Hydrate before launch or after exit. `POST /launch` is refused for the duration, so a launch cannot slip in mid-replace.
 - Dashboard crash recovery is *not* blocked during a replace: the gameless dashboard never opens a memory card, and the swap is atomic, so a relaunch mid-hydrate sees either the old card or the new one
 - Returns `409` if a game is running, a launch is in progress, or another card operation is in progress
-- Returns `400` for a bad/truncated archive, a member escaping the card dir, or when no Slot-1 card is configured
+- Returns `400` for a missing/empty/truncated body, a bad archive, a member escaping the card dir, when no Slot-1 card is configured, or when Slot 1 already holds a File (`.ps2`) card instead of a Folder card
+- Returns `413` if the body exceeds 256 MB
 
 ```json
 { "status": "ok", "written": 42 }
@@ -379,6 +392,10 @@ Sets or toggles the mute state.
 { "status": "ok", "mute": true }
 ```
 
+`mute` in the response is read back from PulseAudio after the change, not just echoed from the request.
+
+- Returns `500` if `pactl` fails (PulseAudio not ready)
+
 ---
 
 ### `POST /cleanup`
@@ -399,28 +416,30 @@ Use this if controller inputs become unresponsive. Under normal operation the `r
 docker logs pcsx2 | grep broker
 ```
 
-Expected startup:
+Expected startup (PCSX2 is launched into the dashboard before the HTTP server starts listening):
 ```
-14:20:15 [broker] INFO Broker starting — waiting 5s for desktop...
-14:20:21 [broker] INFO ROM broker listening on port 8000
-14:20:21 [broker] INFO Shared secret auth enabled
-14:20:23 [broker] INFO Launching PCSX2 (rom=dashboard)
-14:20:24 [broker] INFO PCSX2 launched (PID 42)
+14:20:15 [broker] INFO Broker starting — waiting for desktop X display...
+14:20:16 [broker] INFO Desktop ready on DISPLAY=:1
+14:20:16 [broker] INFO Launching PCSX2 (rom=dashboard)
+14:20:17 [broker] INFO PCSX2 launched (PID 42, initial save slot 1)
+14:20:17 [broker] INFO ROM broker listening on port 8000
+14:20:17 [broker] INFO Shared secret auth enabled
 ```
 
 Expected on game launch:
 ```
 14:22:10 [broker] INFO Stopping PCSX2 (PID 42)...
 14:22:10 [broker] INFO Launching PCSX2 (rom=/romm/library/ps2/game.chd)
-14:22:11 [broker] INFO PCSX2 launched (PID 123)
+14:22:11 [broker] INFO PCSX2 launched (PID 123, initial save slot 1)
 ```
 
-Expected on save-and-exit:
+Expected on save-and-exit (PINE is tried first; xdotool only appears if PINE is unreachable):
 ```
-14:25:45 [broker] INFO xdotool: F1 sent to window 0x3a00007 (slot 10) — waiting for write (max 20.0s)
-14:25:48 [broker] INFO Stopping PCSX2 (PID 123)...
-14:25:49 [broker] INFO Launching PCSX2 (rom=dashboard)
-14:25:49 [broker] INFO PCSX2 launched (PID 456)
+14:25:45 [broker] INFO PINE: save state accepted (slot 10) — waiting for write (max 20.0s)
+14:25:45 [broker] INFO Save: state write complete — SLUS-12345 (ABCD1234).10.p2s (285212 bytes) in 0.3s
+14:25:45 [broker] INFO Stopping PCSX2 (PID 123)...
+14:25:48 [broker] INFO Launching PCSX2 (rom=dashboard)
+14:25:49 [broker] INFO PCSX2 launched (PID 456, initial save slot 1)
 ```
 
 ---
@@ -463,7 +482,7 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 | Feature | Status | Notes |
 |---|---|---|
 | Game launching via RomM | ✅ Done | `POST /launch` |
-| Save state on exit | ✅ Done | `POST /save-and-exit` — xdotool F-key to PCSX2 window, slot 10 default |
+| Save state on exit | ✅ Done | `POST /save-and-exit` — PINE, falling back to xdotool F-key, slot 10 default |
 | Return to dashboard on exit | ✅ Done | Automatic after any exit path |
 | Volume control | ✅ Done | `POST /volume` and `POST /mute` via `pactl` |
 | Manual save state (no exit) | ✅ Done | `POST /save-state` with slot selection |
@@ -490,9 +509,10 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 - Run: `docker exec pcsx2 ls /tmp/selkies_js*.sock` to verify Selkies socket files exist
 
 **Save state fails**
-- Check broker logs for xdotool output: `docker logs pcsx2 | grep xdotool`
-- Verify the PCSX2 window is found: look for `xdotool: found window` in logs
-- If window not found, confirm `xdotool` is installed: `docker exec pcsx2 which xdotool`
+- Saves go over PINE first (`docker logs pcsx2 | grep PINE`); xdotool is only used as a fallback when PINE is unreachable, so no `xdotool` log lines is normal on a healthy container
+- If you do see `PINE unavailable — falling back to xdotool`, check broker logs for xdotool output: `docker logs pcsx2 | grep xdotool`
+- The xdotool window-search success message (`xdotool: found window ...`) is logged at DEBUG — set `BROKER_LOG_LEVEL=DEBUG` to see it; the failure message (`PCSX2 window not found`) is logged at WARNING and shows by default
+- If the window isn't found, confirm `xdotool` is installed: `docker exec pcsx2 which xdotool`
 - Increase `PINE_WAIT` (default 20s) if saves are slow: `PINE_WAIT=30.0`
 - Save files land at `SSTATE_DIR` (`/config/.config/PCSX2/sstates` by default): `docker exec pcsx2 ls /config/.config/PCSX2/sstates`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Slot1_Filename = my-folder-card.ps2   # this is a directory on disk, not a file
 
 | Variable | Default | Description |
 |---|---|---|
-| `BROKER_SECRET` | *(none)* | Shared secret for authentication. Sent as the `X-Broker-Secret` header. If unset, all requests are accepted — not recommended on a shared network. |
+| `BROKER_SECRET` | *(none)* | Shared secret for authentication. Sent as the `X-Broker-Secret` header. If unset, all requests are accepted, which is not safe on a shared network. |
 | `BROKER_PORT` | `8000` | Port the broker HTTP server listens on. |
 | `ROM_ROOT` | `/romm/library` | Root path inside the container where ROMs are mounted. Requests with a `rom_path` outside this directory are rejected. |
 | `PINE_WAIT` | `20.0` | Maximum seconds to poll for save state write completion after a save is accepted, whether the save was delivered via PINE (PCSX2's native IPC socket, tried first) or the xdotool F-key fallback. Polling stops early once the write is detected. Increase for slow disks or large games. |
@@ -96,10 +96,10 @@ Slot1_Filename = my-folder-card.ps2   # this is a directory on disk, not a file
 | `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game VM to reach running state before giving up on the deferred state load. |
 | `RESUME_LOAD_SETTLE` | `3.0` | Seconds to let the game settle after the VM reports running, before the deferred `load_slot` state load fires. |
 | `SAVE_DATA_ROOT` | `/config/.config/PCSX2` | Override for the PCSX2 data dir the `/save-file` and `/memory-card` endpoints operate on. Only the `memcards/` subtree under it is synced. |
-| `BROKER_INITIAL_SLOT` | `1` | Fallback save state slot the broker assumes PCSX2 starts on when `SaveStateSlot` can't be read from `PCSX2.ini`. Only affects xdotool slot cycling — PINE saves/loads carry the target slot directly and don't need it. |
+| `BROKER_INITIAL_SLOT` | `1` | Fallback save state slot the broker assumes PCSX2 starts on when `SaveStateSlot` can't be read from `PCSX2.ini`. Only affects xdotool slot cycling; PINE saves and loads carry the target slot directly. |
 | `PCSX2_LOG_PATH` | `/config/pcsx2-qt.log` | File that captures pcsx2-qt's stdout/stderr (renderer, Vulkan, Qt errors). Appended across launches. |
 | `BROKER_LOG_LEVEL` | `INFO` | Broker log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Note: the xdotool window-search success logs (`xdotool: found window ...`) are DEBUG-level; set `BROKER_LOG_LEVEL=DEBUG` to see them. |
-| `PUID` / `PGID` | `1000` / `1000` | Standard LinuxServer container UID/GID. The broker also uses these directly to `chown` files it writes on PCSX2's behalf — `pcsx2-qt.log`, pulled save-state files, and restored save/memory-card files — so pcsx2-qt (running as `abc`) can read and overwrite them later. |
+| `PUID` / `PGID` | `1000` / `1000` | Standard LinuxServer container UID/GID. The broker also uses them to `chown` the files it writes on PCSX2's behalf (`pcsx2-qt.log`, pulled save-state files, restored save and memory-card files) so pcsx2-qt, which runs as `abc`, can read and overwrite them later. |
 
 ---
 
@@ -113,7 +113,7 @@ streaming:
   containers:
     - platform: ps2
       host: "https://192.168.x.x:3001"        # browser-facing Selkies web UI
-      broker_host: "http://pcsx2:8000"        # server-to-server broker API (optional — derived from host if omitted)
+      broker_host: "http://pcsx2:8000"        # server-to-server broker API (optional; derived from host if omitted)
       label: "PCSX2"
 ```
 
@@ -123,7 +123,7 @@ The `platform` value must match the platform slug used for your PS2 ROMs in RomM
 
 ## API Reference
 
-All endpoints return JSON except the raw-bytes/zip bodies noted below. If `BROKER_SECRET` is configured, include `X-Broker-Secret: <secret>` in every request; a missing or wrong secret returns `403 {"error": "forbidden"}`. `GET /health` is the one exception — it never checks the secret, so it can be used as an unauthenticated container healthcheck.
+All endpoints return JSON except the raw-bytes/zip bodies noted below. If `BROKER_SECRET` is configured, include `X-Broker-Secret: <secret>` in every request; a missing or wrong secret returns `403 {"error": "forbidden"}`. `GET /health` is the one exception. It never checks the secret, so it works as an unauthenticated container healthcheck.
 
 JSON request bodies over 64 KB are rejected with `413`; a body that isn't valid JSON, or isn't a JSON object, is rejected with `400`. This applies to every `POST` endpoint below that takes a body (`/launch`, `/save-and-exit`, `/volume`, `/mute`, `/save-state`, `/load-state`).
 
@@ -153,11 +153,17 @@ Returns the current session.
 }
 ```
 
-`active` reflects whether a pcsx2-qt process is alive at all — **the idle dashboard counts as active too.** It is not "a game is running"; use `rom_path` for that (non-null only when an actual ROM is loaded, `null` for the dashboard). `rom_name` and `started_at` are `null` unless a game is loaded, and all three of `rom_path`/`rom_name`/`started_at` are forced to `null` in the response whenever `active` is `false`, regardless of what the broker still has cached internally.
+`active` means a pcsx2-qt process is alive. It does **not** mean a game is running: the idle dashboard is a normal pcsx2-qt process, so an idle container reports `active: true`. To test for a running game, check `rom_path`, which is non-null only when a ROM is loaded and `null` on the dashboard. `rom_name` and `started_at` follow `rom_path`, and all three are reported as `null` whenever `active` is `false`, whatever the broker still holds internally.
 
-`active` is `false` only briefly during a kill-then-relaunch sequence, or persistently once the crash-loop limiter has given up.
+`relaunch_abandoned` turns `true` once PCSX2 has exited within 5 seconds three times in a row and the broker has stopped restarting it. Nothing is running, and nothing will recover it without an explicit `POST /launch`. The two fields together tell you which state a quiet container is in:
 
-`relaunch_abandoned` is `true` once PCSX2 has exited within 5 s three times in a row and the broker has stopped restarting it — nothing is running and nothing will recover it without an explicit `POST /launch`. Monitor this to tell a container idle at the dashboard (`active: true`, `rom_path: null`, `relaunch_abandoned: false`) from one that has given up (`active: false`, `relaunch_abandoned: true`); the latter needs intervention, usually a GPU/renderer failure visible in `PCSX2_LOG_PATH`.
+| `active` | `relaunch_abandoned` | Meaning |
+|---|---|---|
+| `true` | `false` | Idle at the dashboard, waiting for a launch. Healthy. |
+| `false` | `false` | Mid-handoff between two processes. Recheck in a second. |
+| `false` | `true` | The broker gave up restarting PCSX2. Needs intervention. |
+
+The last row usually means a GPU or renderer failure, which will be visible in `PCSX2_LOG_PATH`.
 
 ---
 
@@ -169,8 +175,8 @@ Kills any running game and launches a new ROM. Returns immediately; launch runs 
 { "rom_path": "/romm/library/ps2/game.chd", "load_slot": 3 }
 ```
 
-- `rom_path` must exist and be under `ROM_ROOT`. `rom_name` (as shown in `/status`) is not read from the request — it is always derived from `rom_path`'s filename stem.
-- `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
+- `rom_path` must exist and be under `ROM_ROOT`. `rom_name` (as shown in `/status`) is not read from the request; it is always derived from `rom_path`'s filename stem.
+- `load_slot` (optional, 1–10) resumes from a save state. Once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace period), the broker loads that slot. Push the state file with `PUT /state-file` before launching.
 - Returns `409` if a save is in progress, a launch is already in progress, or a `/memory-card` replace is in flight
 - Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10
 - Returns `422` if `rom_path` does not exist
@@ -226,7 +232,7 @@ Save states are written to `SSTATE_DIR` as `{SERIAL} ({CRC}).{slot:02d}.p2s`.
 
 ### `POST /save-state`
 
-Saves the current game to a slot without exiting, via PINE (falling back to an xdotool F-key press if PINE is unreachable). The save runs in the background, so a `200` means the save was dispatched — not that the write finished. `/status` does not expose a `save_in_progress` field; to confirm the write completed, `GET /state-file` for the same slot — it blocks until any in-flight save finishes (up to `STATE_GET_WAIT`) rather than serving a stale or half-written file. A second `/save-state` call while one is still running gets `409`.
+Saves the current game to a slot without exiting, via PINE (falling back to an xdotool F-key press if PINE is unreachable). The save runs in the background, so a `200` means the save was dispatched, not that the write finished. `/status` does not expose a `save_in_progress` field. To confirm the write completed, call `GET /state-file` for the same slot: it blocks until any in-flight save finishes (up to `STATE_GET_WAIT`) rather than serving a stale or half-written file. A second `/save-state` call while one is still running gets `409`.
 
 ```json
 { "slot": 1 }
@@ -278,7 +284,7 @@ Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centra
 - Response body is `application/octet-stream`; the emulator's own filename is echoed in the `X-State-Filename` header
 - Returns `404` if no state file exists for the slot
 - Returns `400` if `slot` is not an integer 0–10
-- Returns `503` if a save is still in flight after `STATE_GET_WAIT` — retry rather than accept a half-written file
+- Returns `503` if a save is still in flight after `STATE_GET_WAIT`. Retry rather than accept a half-written file
 - Returns `413` if the state file exceeds 256 MB
 - Returns `500` if the state file can't be read (filesystem error)
 
@@ -286,7 +292,7 @@ Serves the newest `.p2s` state file for the slot as raw bytes, for RomM's centra
 
 ### `PUT /state-file?filename=NAME`
 
-Writes a state file into the sstates directory, used by RomM to hydrate a freshly claimed container with the user's stored states. `NAME` is the filename a previous GET returned — written back verbatim so PCSX2 recognises the slot.
+Writes a state file into the sstates directory, used by RomM to hydrate a freshly claimed container with the user's stored states. `NAME` is the filename a previous GET returned, written back verbatim so PCSX2 recognises the slot.
 
 - Body is the raw file content (`Content-Length` required, max 256 MB)
 - `NAME` must be a bare `.p2s` basename that doesn't start with a dot; path components are rejected
@@ -309,9 +315,9 @@ Zips every in-game save (memory-card file under `memcards/`) modified since the 
 - Response body is `application/zip`; a suggested name is echoed in `X-Save-Filename`
 - Files still being written are skipped; their count is reported in `X-Save-Skipped-Unstable`
 - Returns `404 {"error": "no game has been launched"}` if the broker has never launched a ROM this session
-- Returns `404 {"error": "no save changes since last launch"}` when nothing under `memcards/` changed since the last game launch — this is the expected steady-state response between saves, not a failure; poll again after the player actually saves
+- Returns `404 {"error": "no save changes since last launch"}` when nothing under `memcards/` has changed since the last game launch. This is the expected steady-state response between saves, not a failure. Poll again after the player saves
 - Returns `413` if the changed set exceeds 256 MB
-- Returns `503` if every changed file was mid-write — retry shortly
+- Returns `503` if every changed file was mid-write. Retry shortly
 
 ---
 
@@ -323,7 +329,7 @@ Restores a previously pulled save archive into the data dir, used to hydrate a c
 - Archive members must live under `memcards/`; anything else is rejected
 - Returns `400` for a missing/empty/truncated body, a bad archive, or a member outside the allowed subtree
 - Returns `413` if the body exceeds 256 MB
-- Returns `500` if some members could not be written — the response carries `written`/`skipped`/`failed` counts, and retrying the same archive is safe (idempotent)
+- Returns `500` if some members could not be written. The response carries `written`, `skipped` and `failed` counts, and retrying the same archive is safe (idempotent)
 
 ```json
 { "status": "ok", "written": 3, "skipped": 1 }
@@ -336,17 +342,17 @@ Restores a previously pulled save archive into the data dir, used to hydrate a c
 Serves the **entire** Slot-1 folder memory card (superblock plus every game folder) as one zip, member paths relative to the card root so the image is host- and card-name-independent. This is the per-user card evacuation for pooled containers; Slot 2 is never touched.
 
 - Response is `application/zip` with `X-Memory-Card-Slot: 1`
-- Returns `404` with header `X-Memory-Card: absent` if no folder card exists in slot 1 — the header distinguishes "genuinely empty" from a missing endpoint, which must not be treated as safe-to-wipe
-- Returns `409` if slot 1 is a File (`.ps2`) card — the whole-card sync requires a Folder card — or if another card operation is in progress
+- Returns `404` with header `X-Memory-Card: absent` if no folder card exists in slot 1. The header distinguishes "genuinely empty" from a missing endpoint, which must not be treated as safe to wipe
+- Returns `409` if slot 1 holds a File (`.ps2`) card, since whole-card sync requires a Folder card, or if another card operation is in progress
 
 ---
 
 ### `PUT /memory-card`
 
-Wipes the Slot-1 folder card and lays down the pulled card image (no per-file merge — full replace is the isolation guarantee for pooled containers). Extraction goes to a staging dir swapped atomically over the live card, so a mid-way failure never leaves a half-wiped card.
+Wipes the Slot-1 folder card and lays down the pulled card image. There is no per-file merge; a full replace is what guarantees isolation between users of a pooled container. Extraction goes to a staging dir swapped atomically over the live card, so a mid-way failure never leaves a half-wiped card.
 
 - Body is the raw zip (`Content-Length` required, max 256 MB)
-- Refused while a game is running or a launch is in flight — PCSX2 holds the card open and replacing it mid-game corrupts it. Hydrate before launch or after exit. `POST /launch` is refused for the duration, so a launch cannot slip in mid-replace.
+- Refused while a game is running or a launch is in flight. PCSX2 holds the card open, and replacing it mid-game corrupts it, so hydrate before launch or after exit. `POST /launch` is refused for the duration, so a launch cannot slip in mid-replace.
 - Dashboard crash recovery is *not* blocked during a replace: the gameless dashboard never opens a memory card, and the swap is atomic, so a relaunch mid-hydrate sees either the old card or the new one
 - Returns `409` if a game is running, a launch is in progress, or another card operation is in progress
 - Returns `400` for a missing/empty/truncated body, a bad archive, a member escaping the card dir, when no Slot-1 card is configured, or when Slot 1 already holds a File (`.ps2`) card instead of a Folder card
@@ -446,7 +452,7 @@ Expected on save-and-exit (PINE is tried first; xdotool only appears if PINE is 
 
 ## Development
 
-The broker's logic is covered by a stdlib `unittest` suite — no pytest, no dependencies, nothing to install. Run it from the repo root:
+The broker's logic is covered by a stdlib `unittest` suite. There is no pytest and nothing to install, which matters because the container has no pip. Run it from the repo root:
 
 ```bash
 python3 -m unittest discover -s tests -v
@@ -456,17 +462,17 @@ python3 -m unittest discover -s tests -v
 
 The suite covers the save-file and memory-card archive handling (round trips, the last-write-wins mtime guard, path-traversal and subtree rejection, File-card refusal), `PCSX2.ini` patching and parsing, ROM path validation, and the session lifecycle state machine (crash-loop limiter, launch/card-op claims, deferred `load_slot` generation checks).
 
-Anything needing a real X display, PINE socket, or `pcsx2-qt` process is deliberately out of scope — those paths are only provable on a running container.
+Anything needing a real X display, PINE socket, or `pcsx2-qt` process is deliberately out of scope. Those paths are only provable on a running container.
 
 ---
 
 ## Pinning to a Version
 
 ```yaml
-# Exact version — never changes
+# Exact version, never changes
 - DOCKER_MODS=ghcr.io/loneangelfayt/pcsx2-romm-integration-mod:v1.2.0
 
-# Minor pin — gets patches only
+# Minor pin, gets patches only
 - DOCKER_MODS=ghcr.io/loneangelfayt/pcsx2-romm-integration-mod:v1.2
 
 # Always latest release
@@ -481,13 +487,16 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 
 | Feature | Status | Notes |
 |---|---|---|
-| Game launching via RomM | ✅ Done | `POST /launch` |
-| Save state on exit | ✅ Done | `POST /save-and-exit` — PINE, falling back to xdotool F-key, slot 10 default |
-| Return to dashboard on exit | ✅ Done | Automatic after any exit path |
-| Volume control | ✅ Done | `POST /volume` and `POST /mute` via `pactl` |
-| Manual save state (no exit) | ✅ Done | `POST /save-state` with slot selection |
-| Manual load state | ✅ Done | `POST /load-state` with slot selection |
-| RomM save state export/import | ✅ Done | `GET`/`PUT /state-file` — RomM pulls saves into the library and hydrates slots on claim |
+| Game launching via RomM | Done | `POST /launch` |
+| Save state on exit | Done | `POST /save-and-exit`, over PINE with an xdotool F-key fallback, slot 10 by default |
+| Return to dashboard on exit | Done | Automatic after any exit path |
+| Volume control | Done | `POST /volume` and `POST /mute` via `pactl` |
+| Manual save state (no exit) | Done | `POST /save-state` with slot selection |
+| Manual load state | Done | `POST /load-state` with slot selection |
+| RomM save state export/import | Done | `GET`/`PUT /state-file`. RomM pulls states into the library and hydrates slots on claim |
+| Resume from a save state on launch | Done | `load_slot` on `POST /launch` |
+| In-game save sync | Done | `GET`/`PUT /save-file`. Delta pull of changed memory-card saves, restored last-write-wins |
+| Whole memory-card sync | Done | `GET`/`PUT /memory-card`. Full Slot-1 folder card evacuate and hydrate for pooled containers |
 
 ---
 
@@ -511,14 +520,23 @@ Available versions: [Packages page](https://github.com/LoneAngelFayt/pcsx2-romm-
 **Save state fails**
 - Saves go over PINE first (`docker logs pcsx2 | grep PINE`); xdotool is only used as a fallback when PINE is unreachable, so no `xdotool` log lines is normal on a healthy container
 - If you do see `PINE unavailable — falling back to xdotool`, check broker logs for xdotool output: `docker logs pcsx2 | grep xdotool`
-- The xdotool window-search success message (`xdotool: found window ...`) is logged at DEBUG — set `BROKER_LOG_LEVEL=DEBUG` to see it; the failure message (`PCSX2 window not found`) is logged at WARNING and shows by default
+- The xdotool window-search success message (`xdotool: found window ...`) is logged at DEBUG, so set `BROKER_LOG_LEVEL=DEBUG` to see it. The failure message (`PCSX2 window not found`) is logged at WARNING and shows by default
 - If the window isn't found, confirm `xdotool` is installed: `docker exec pcsx2 which xdotool`
 - Increase `PINE_WAIT` (default 20s) if saves are slow: `PINE_WAIT=30.0`
 - Save files land at `SSTATE_DIR` (`/config/.config/PCSX2/sstates` by default): `docker exec pcsx2 ls /config/.config/PCSX2/sstates`
 
 **PCSX2 crashes immediately after game launch**
 - Check emulog for GPU or BIOS errors
+- Check `PCSX2_LOG_PATH` (`/config/pcsx2-qt.log` by default) for renderer and Vulkan errors, which is where a shader compilation failure shows up
 - Ensure the game file is not corrupted: `.chd`, `.iso`, `.bin/.cue` are all supported
+
+**Nothing restarts after repeated crashes**
+- Check `GET /status`. If `relaunch_abandoned` is `true`, PCSX2 exited within 5 seconds three times in a row and the broker deliberately stopped restarting it rather than respawning a broken process forever
+- Fix the underlying failure first (usually GPU or BIOS, visible in `PCSX2_LOG_PATH`), then `POST /launch` to recover. A successful launch clears the flag
+
+**A game "launches" but never boots**
+- An unbootable or corrupt ROM does not crash PCSX2. The process stays alive on an error dialog, so `/status` reports an active session and the crash-loop limiter never engages
+- Confirm the file is a valid disc image and that BIOS files are present in `/config/bios`
 
 **RomM doesn't show the PCSX2 play button**
 - Confirm `streaming.enabled: true` in RomM's `config.yml`

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -237,15 +237,15 @@ def _patch_ini():
         # doesn't exist at all we create it so PCSX2 picks the value up.
         missing = [(sec, key, val) for (sec, key), val in patches.items() if (sec, key) not in applied]
         if missing:
-            present_sections = {l.strip()[1:-1] for l in new_lines if l.strip().startswith("[") and l.strip().endswith("]")}
+            present_sections = {line.strip()[1:-1] for line in new_lines if line.strip().startswith("[") and line.strip().endswith("]")}
             for sec, _key, val in missing:
                 if sec in present_sections:
                     # Insert immediately after the section header.
                     out: list[str] = []
                     inserted = False
-                    for l in new_lines:
-                        out.append(l)
-                        if not inserted and l.strip() == f"[{sec}]":
+                    for line in new_lines:
+                        out.append(line)
+                        if not inserted and line.strip() == f"[{sec}]":
                             out.append(val)
                             inserted = True
                     new_lines = out

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Lint baseline shared by every RomM integration repo. The ruff version is
+# pinned in .github/workflows/ci.yml so a new ruff release cannot turn CI red
+# on code nobody touched; bump both together.
+line-length = 100
+target-version = "py311"
+
+[lint]
+# E,F,W is clean across all five brokers today. I/UP/B are the natural next
+# step but need a one-off cleanup pass first.
+select = ["E", "F", "W"]
+# Long ini-patch and URL lines are everywhere in the brokers; not worth a reflow.
+ignore = ["E501"]


### PR DESCRIPTION
Everything on `dev` that is not already in `main`, minus the folder-organized ROM hotfix, which goes in separately as #12.

## CI

- Adds `ci.yml` (ruff + pytest) as a reusable workflow and makes both publish paths depend on it. `dev.yml` pushed `:dev` on every non-main push and `build.yml` released from `main` unconditionally, so neither ran a test.
- `EXPECT_TESTS` guards against a repo silently losing its suite: without it, a deleted or unstaged `tests/` downgrades `ci-test` to a lint-only gate and still reports green.
- Adds `ruff.toml`, the shared lint baseline (`E,F,W`, `E501` ignored, ruff version pinned in `ci.yml`).
- Renames `l` to `line` in `_patch_ini` to clear ruff E741. Behavior is identical.

## Docs

- Corrects the README against what the broker actually implements.
- Completes the roadmap and rewrites the `/status` section as a table mapping `active` and `relaunch_abandoned` to what the container is really doing, plus troubleshooting entries for the crash-loop limiter and unbootable ROMs.

No broker behavior changes. 62/62 tests pass.
