### PR TITLE
docs: drop the duplicated /launch bullets left by the merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,8 @@ Kills any running game and launches a new ROM. Returns immediately; launch runs 
 { "rom_path": "/romm/library/ps2/game.chd", "load_slot": 3 }
 ```
 
-- `rom_path` must exist and be under `ROM_ROOT`
-- `rom_path` may be a **directory**, for libraries laid out one game per folder (`roms/ps2/Jak 3/Jak 3.iso`). RomM addresses such a game by its folder, so the broker looks inside for the disc image: the folder itself first, then one level down for per-disc subfolders. Candidates are ranked by format (`.chd`, `.iso`, `.cso`, `.zso`, `.gz`, `.mdf`, `.dump`, `.bin`, `.elf`) and then by name, so a multi-disc set boots disc 1. Dot-files are skipped, and a symlink pointing outside `ROM_ROOT` is never chosen. The resolved file is what `/status` and the response body report.
-- `load_slot` (optional, 1–10) — resume-from-state: once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace), the broker loads that state slot. Push the state file via `PUT /state-file` before launching.
 - `rom_path` must exist and be under `ROM_ROOT`. `rom_name` (as shown in `/status`) is not read from the request; it is always derived from `rom_path`'s filename stem.
+- `rom_path` may be a **directory**, for libraries laid out one game per folder (`roms/ps2/Jak 3/Jak 3.iso`). RomM addresses such a game by its folder, so the broker looks inside for the disc image: the folder itself first, then one level down for per-disc subfolders. Candidates are ranked by format (`.chd`, `.iso`, `.cso`, `.zso`, `.gz`, `.mdf`, `.dump`, `.bin`, `.elf`) and then by name, so a multi-disc set boots disc 1. Dot-files are skipped, and a symlink pointing outside `ROM_ROOT` is never chosen. The resolved file is what `/status` and the response body report.
 - `load_slot` (optional, 1–10) resumes from a save state. Once the game VM reports running (checked via PINE `EMU_STATUS`, up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace period), the broker loads that slot. Push the state file with `PUT /state-file` before launching.
 - Returns `409` if a save is in progress, a launch is already in progress, or a `/memory-card` replace is in flight
 - Returns `400` if `rom_path` is missing or outside `ROM_ROOT`, or `load_slot` is not an integer 1–10


### PR DESCRIPTION
Merging #12 and #13 in sequence left the `POST /launch` bullet list with two copies of both `rom_path` and `load_slot`. The hotfix branch was cut from main before #13 rewrote those bullets, so the cherry-pick kept main's older wording and #13 then added dev's alongside it.

Keeps the newer pair (the `rom_path` bullet that also documents how `rom_name` is derived, and the `load_slot` bullet without the truncated grace-period note) and drops the stale duplicates. The `/launch` section now matches `dev` exactly.

Docs only, no code change.